### PR TITLE
Provide new logging facilities and other helpers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: moulinette
 Section: python
 Priority: optional
 Maintainer: Jérôme Lebleu <jerome.lebleu@mailoo.org>
-Build-Depends: debhelper (>= 7.0.50), python (>= 2.7)
-Standards-Version: 3.9.2
+Build-Depends: debhelper (>= 9), python (>= 2.7)
+Standards-Version: 3.9.6
 X-Python-Version: >= 2.7
 Homepage: https://github.com/YunoHost/moulinette
 

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,8 @@ Depends: ${misc:Depends}, ${python:Depends},
     python-yaml,
     python-bottle (>= 0.12),
     python-gnupg,
-    python-gevent-websocket
+    python-gevent-websocket,
+    python-argcomplete
 Replaces: yunohost-cli
 Breaks: yunohost-cli
 Description: prototype interfaces with ease in Python

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,6 +8,8 @@
     "root_required" : "You must be root to perform this action",
     "instance_already_running" : "An instance is already running",
     "error_see_log" : "An error occured. Please see the log for details.",
+    "file_not_exist" : "File does not exist",
+    "folder_not_exist" : "Folder does not exist",
 
     "unable_authenticate" : "Unable to authenticate",
     "unable_retrieve_session" : "Unable to retrieve the session",

--- a/moulinette/__init__.py
+++ b/moulinette/__init__.py
@@ -94,8 +94,7 @@ def api(namespaces, host='localhost', port=80, routes={},
                                              'use_cache': use_cache })
     moulinette.run(host, port)
 
-def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True,
-        parser_kwargs={}):
+def cli(namespaces, args, use_cache=True, output_as=None, parser_kwargs={}):
     """Command line interface
 
     Execute an action with the moulinette from the CLI and print its
@@ -104,10 +103,10 @@ def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True,
     Keyword arguments:
         - namespaces -- The list of namespaces to use
         - args -- A list of argument strings
-        - print_json -- True to print result as a JSON encoded string
-        - print_plain -- True to print result as a script-usable string
         - use_cache -- False if it should parse the actions map file
             instead of using the cached one
+        - output_as -- Output result in another format, see
+            moulinette.interfaces.cli.Interface for possible values
         - parser_kwargs -- A dict of arguments to pass to the parser
             class at construction
 
@@ -120,7 +119,7 @@ def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True,
                 'parser_kwargs': parser_kwargs,
             },
         )
-        moulinette.run(args, print_json, print_plain)
+        moulinette.run(args, output_as=output_as)
     except MoulinetteError as e:
         import logging
         logging.getLogger('yunohost').error(e.strerror)

--- a/moulinette/__init__.py
+++ b/moulinette/__init__.py
@@ -109,14 +109,13 @@ def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True):
             instead of using the cached one
 
     """
-    from moulinette.interfaces.cli import colorize
-
     try:
         moulinette = init_interface('cli',
                                     actionsmap={'namespaces': namespaces,
                                                 'use_cache': use_cache})
         moulinette.run(args, print_json, print_plain)
     except MoulinetteError as e:
-        print('%s %s' % (colorize(m18n.g('error'), 'red'), e.strerror))
+        import logging
+        logging.getLogger('yunohost').error(e.strerror)
         return e.errno
     return 0

--- a/moulinette/__init__.py
+++ b/moulinette/__init__.py
@@ -94,7 +94,8 @@ def api(namespaces, host='localhost', port=80, routes={},
                                              'use_cache': use_cache })
     moulinette.run(host, port)
 
-def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True):
+def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True,
+        parser_kwargs={}):
     """Command line interface
 
     Execute an action with the moulinette from the CLI and print its
@@ -107,12 +108,18 @@ def cli(namespaces, args, print_json=False, print_plain=False, use_cache=True):
         - print_plain -- True to print result as a script-usable string
         - use_cache -- False if it should parse the actions map file
             instead of using the cached one
+        - parser_kwargs -- A dict of arguments to pass to the parser
+            class at construction
 
     """
     try:
         moulinette = init_interface('cli',
-                                    actionsmap={'namespaces': namespaces,
-                                                'use_cache': use_cache})
+            actionsmap={
+                'namespaces': namespaces,
+                'use_cache': use_cache,
+                'parser_kwargs': parser_kwargs,
+            },
+        )
         moulinette.run(args, print_json, print_plain)
     except MoulinetteError as e:
         import logging

--- a/moulinette/__init__.py
+++ b/moulinette/__init__.py
@@ -87,12 +87,26 @@ def api(namespaces, host='localhost', port=80, routes={},
             instead of using the cached one
 
     """
-    moulinette = init_interface('api',
-                                kwargs={ 'routes': routes,
-                                         'use_websocket': use_websocket },
-                                actionsmap={ 'namespaces': namespaces,
-                                             'use_cache': use_cache })
-    moulinette.run(host, port)
+    try:
+        moulinette = init_interface('api',
+            kwargs={
+                'routes': routes,
+                'use_websocket': use_websocket
+            },
+            actionsmap={
+                'namespaces': namespaces,
+                'use_cache': use_cache
+            }
+        )
+        moulinette.run(host, port)
+    except MoulinetteError as e:
+        import logging
+        logging.getLogger('moulinette').error(e.strerror)
+        return e.errno
+    except KeyboardInterrupt:
+        import logging
+        logging.getLogger('moulinette').info(m18n.g('operation_interrupted'))
+    return 0
 
 def cli(namespaces, args, use_cache=True, output_as=None, parser_kwargs={}):
     """Command line interface
@@ -122,6 +136,6 @@ def cli(namespaces, args, use_cache=True, output_as=None, parser_kwargs={}):
         moulinette.run(args, output_as=output_as)
     except MoulinetteError as e:
         import logging
-        logging.getLogger('yunohost').error(e.strerror)
+        logging.getLogger('moulinette').error(e.strerror)
         return e.errno
     return 0

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -342,17 +342,20 @@ class ActionsMap(object):
     all available namespaces.
 
     Keyword arguments:
-        - parser -- The BaseActionsMapParser derived class to use for
-            parsing the actions map
+        - parser_class -- The BaseActionsMapParser derived class to use
+            for parsing the actions map
         - namespaces -- The list of namespaces to use
         - use_cache -- False if it should parse the actions map file
-            instead of using the cached one.
+            instead of using the cached one
+        - parser_kwargs -- A dict of arguments to pass to the parser
+            class at construction
 
     """
-    def __init__(self, parser, namespaces=[], use_cache=True):
-        if not issubclass(parser, BaseActionsMapParser):
-            raise ValueError("Invalid parser class '%s'" % parser.__name__)
-        self._parser_class = parser
+    def __init__(self, parser_class, namespaces=[], use_cache=True,
+                 parser_kwargs={}):
+        if not issubclass(parser_class, BaseActionsMapParser):
+            raise ValueError("Invalid parser class '%s'" % parser_class.__name__)
+        self.parser_class = parser_class
         self.use_cache = use_cache
 
         if len(namespaces) == 0:
@@ -380,8 +383,8 @@ class ActionsMap(object):
             m18n.load_namespace(n)
 
         # Generate parsers
-        self.extraparser = ExtraArgumentParser(parser.interface)
-        self._parser = self._construct_parser(actionsmaps)
+        self.extraparser = ExtraArgumentParser(parser_class.interface)
+        self._parser = self._construct_parser(actionsmaps, **parser_kwargs)
 
     @property
     def parser(self):
@@ -515,13 +518,15 @@ class ActionsMap(object):
 
     ## Private methods
 
-    def _construct_parser(self, actionsmaps):
+    def _construct_parser(self, actionsmaps, **kwargs):
         """
         Construct the parser with the actions map
 
         Keyword arguments:
             - actionsmaps -- A dict of multi-level dictionnary of
                 categories/actions/arguments list for each namespaces
+            - **kwargs -- Additionnal arguments to pass at the parser
+                class instantiation
 
         Returns:
             An interface relevant's parser object
@@ -551,7 +556,7 @@ class ActionsMap(object):
                     parser.add_argument(*names, **argp)
 
         # Instantiate parser
-        top_parser = self._parser_class()
+        top_parser = self.parser_class(**kwargs)
 
         # Iterate over actions map namespaces
         for n, actionsmap in actionsmaps.items():

--- a/moulinette/authenticators/__init__.py
+++ b/moulinette/authenticators/__init__.py
@@ -151,7 +151,7 @@ class BaseAuthenticator(object):
         except IOError:
             logger.debug("unable to retrieve session", exc_info=1)
             raise MoulinetteError(errno.ENOENT,
-                                  m18r.g('unable_retrieve_session'))
+                                  m18n.g('unable_retrieve_session'))
         else:
             gpg = gnupg.GPG()
             gpg.encoding = 'utf-8'
@@ -161,5 +161,5 @@ class BaseAuthenticator(object):
                 logger.error("unable to decrypt password for the session: %s",
                              decrypted.status)
                 raise MoulinetteError(errno.EINVAL,
-                                      m18r.g('unable_retrieve_session'))
+                                      m18n.g('unable_retrieve_session'))
             return decrypted.data

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -31,7 +31,7 @@ class BaseActionsMapParser(object):
         - parent -- A parent BaseActionsMapParser derived object
 
     """
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, **kwargs):
         if parent:
             self._o = parent
         else:

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -476,7 +476,7 @@ class ActionsMapParser(BaseActionsMapParser):
     the arguments is represented by a ExtendedArgumentParser object.
 
     """
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, **kwargs):
         super(ActionsMapParser, self).__init__(parent)
 
         self._parsers = {} # dict({(method, path): _HTTPArgumentParser})

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -278,7 +278,7 @@ class Interface(BaseInterface):
 
         self.actionsmap = actionsmap
 
-    def run(self, args, print_json=False, print_plain=False):
+    def run(self, args, output_as=None):
         """Run the moulinette
 
         Process the action corresponding to the given arguments 'args'
@@ -286,11 +286,12 @@ class Interface(BaseInterface):
 
         Keyword arguments:
             - args -- A list of argument strings
-            - print_json -- True to print result as a JSON encoded string
-            - print_plain -- True to print result as a script-usable string
+            - output_as -- Output result in another format. Possible values:
+                - json: return a JSON encoded string
+                - plain: return a script-readable output
 
         """
-        if print_json and print_plain:
+        if output_as and output_as not in ['json', 'plain']:
             raise MoulinetteError(errno.EINVAL, m18n.g('invalid_usage'))
 
         try:
@@ -302,12 +303,13 @@ class Interface(BaseInterface):
             return
 
         # Format and print result
-        if print_json:
-            import json
-            from moulinette.utils.serialize import JSONExtendedEncoder
-            print(json.dumps(ret, cls=JSONExtendedEncoder))
-        elif print_plain:
-            plain_print_dict(ret)
+        if output_as:
+            if output_as == 'json':
+                import json
+                from moulinette.utils.serialize import JSONExtendedEncoder
+                print(json.dumps(ret, cls=JSONExtendedEncoder))
+            else:
+                plain_print_dict(ret)
         elif isinstance(ret, dict):
             pretty_print_dict(ret)
         else:

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import errno
 import getpass
 import locale
-import logging
 
 from moulinette.core import MoulinetteError
 from moulinette.interfaces import (
     BaseActionsMapParser, BaseInterface, ExtendedArgumentParser,
 )
+from moulinette.utils import log
 
 
-logger = logging.getLogger('moulinette.cli')
+logger = log.getLogger('moulinette.cli')
 
 
 # CLI helpers ----------------------------------------------------------
@@ -125,6 +126,42 @@ def get_locale():
 
 
 # CLI Classes Implementation -------------------------------------------
+
+class TTYHandler(log.StreamHandler):
+    """
+    A handler class which prints logging records, with colorized message,
+    to a tty.
+    """
+    LEVELS_COLOR = {
+        log.NOTSET   : 'white',
+        log.DEBUG    : 'white',
+        log.INFO     : 'cyan',
+        log.SUCCESS  : 'green',
+        log.WARNING  : 'yellow',
+        log.ERROR    : 'red',
+        log.CRITICAL : 'red',
+    }
+
+    def __init__(self):
+        log.StreamHandler.__init__(self, stream=sys.stdout)
+        if os.isatty(1):
+            self.colorized = True
+        else:
+            self.colorized = False
+
+    def format(self, record):
+        msg = record.getMessage()
+        if self.colorized:
+            level = ''
+            if self.level <= log.DEBUG:
+                level = '%s ' % record.levelname
+            elif record.levelname in ['SUCCESS', 'WARNING', 'ERROR']:
+                level = '%s ' % m18n.g(record.levelname.lower())
+            color = self.LEVELS_COLOR.get(record.levelno, 'white')
+            msg = '\033[{0}m\033[1m{1}\033[m{2}'.format(
+                colors_codes[color], level, msg)
+        return msg
+
 
 class ActionsMapParser(BaseActionsMapParser):
     """Actions map's Parser for the CLI

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -7,6 +7,8 @@ import getpass
 import locale
 from argparse import SUPPRESS
 
+import argcomplete
+
 from moulinette.core import MoulinetteError
 from moulinette.interfaces import (
     BaseActionsMapParser, BaseInterface, ExtendedArgumentParser,
@@ -293,6 +295,9 @@ class Interface(BaseInterface):
         """
         if output_as and output_as not in ['json', 'plain']:
             raise MoulinetteError(errno.EINVAL, m18n.g('invalid_usage'))
+
+        # auto-complete
+        argcomplete.autocomplete(self.actionsmap.parser._parser)
 
         try:
             ret = self.actionsmap.process(args, timeout=5)

--- a/moulinette/utils/log.py
+++ b/moulinette/utils/log.py
@@ -49,6 +49,19 @@ def configure_logging(logging_config=None):
     if logging_config:
         dictConfig(logging_config)
 
+def getHandlersByClass(classinfo, limit=0):
+    """Retrieve registered handlers of a given class."""
+    handlers = []
+    for ref in logging._handlers.itervaluerefs():
+        o = ref()
+        if o is not None and isinstance(o, classinfo):
+            if limit == 1:
+                return o
+            handlers.append(o)
+    if limit != 0 and len(handlers) > limit:
+        return handlers[:limit-1]
+    return handlers
+
 
 class MoulinetteLogger(Logger):
     """Custom logger class

--- a/moulinette/utils/log.py
+++ b/moulinette/utils/log.py
@@ -100,7 +100,8 @@ class MoulinetteLogger(Logger):
         if self.action_id is not None:
             extra = kwargs.get('extra', {})
             if not 'action_id' in extra:
-                extra['action_id'] = self.action_id
+                # FIXME: Get real action_id instead of logger/current one
+                extra['action_id'] = _get_action_id()
                 kwargs['extra'] = extra
         return Logger._log(self, *args, **kwargs)
 


### PR DESCRIPTION
It aims to remove the *display* signals and replace it by the `logging` module. Thanks to some tweaks and configurations, it comes with at least the same features and also more, such as:
 * join logging and messages display in one place to make it easier to control and use
 * select what to log, when and where
 * do not re-invent the wheel, the logging configuration is straight enough to be extended!

Note that it's still compatible with the old-and-soon-deprecated `msignals.display` function in order to facilitate merging and by the way tests.

It also come with some other features such as bash-completion - which still need to be activated per project.