### PR TITLE
increase cli timeout

### DIFF
--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -349,7 +349,7 @@ class Interface(BaseInterface):
                                  lambda a,h: a(password=password))
 
         try:
-            ret = self.actionsmap.process(args, timeout=5)
+            ret = self.actionsmap.process(args, timeout=30)
         except KeyboardInterrupt, EOFError:
             raise MoulinetteError(errno.EINTR, m18n.g('operation_interrupted'))
 


### PR DESCRIPTION
Hello,

This isn't a great solution but could avoid some bug: it increases the timeout of a cli command from 5 to 30 while we don't have a <code>--wait</code> option.

This is a small decision.