### PR TITLE
[fix] at installation the cache dir might not be present

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -523,10 +523,12 @@ class ActionsMap(object):
             with open(am_file, 'r') as f:
                 actionsmaps[n] = yaml.load(f)
 
-            # clean old cached files
-            for i in os.listdir('%s/actionsmap/' % pkg.cachedir):
-                if i.endswith(".pkl"):
-                    os.remove('%s/actionsmap/%s' % (pkg.cachedir, i))
+            # at installation, cachedir might not exists
+            if os.path.exists('%s/actionsmap/' % pkg.cachedir):
+                # clean old cached files
+                for i in os.listdir('%s/actionsmap/' % pkg.cachedir):
+                    if i.endswith(".pkl"):
+                        os.remove('%s/actionsmap/%s' % (pkg.cachedir, i))
 
             # Cache actions map into pickle file
             am_file_stat = os.stat(am_file)


### PR DESCRIPTION
Hello,

During installation the cache dir might not be present, it is created at this line using a magical helper https://github.com/YunoHost/moulinette/blob/54a50a40b9b678579041e5a8eee2b61e77536aac/moulinette/actionsmap.py#L538

This might that listing a non-existing dir raise an exception and break the installation. This bug is therefor *critical* and needs to be merged (or another solution) before we make a release.

This is a minor decision.