### PR TITLE
Unfinished process bug

### DIFF
--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -81,6 +81,17 @@ def call_async_output(args, callback, **kwargs):
             time.sleep(.1)
     stdout_reader.join()
     stdout_consum.join()
+
+    # on slow hardware, in very edgy situations it is possible that the process
+    # isn't finished just after having closed stdout and stderr, so we wait a
+    # bit to give hime the time to finish (while having a timeout)
+    # Note : p.poll() returns None is the process hasn't finished yet
+    start = time.time()
+    while time.time() - start < 10:
+        if p.poll() is not None:
+            return p.poll()
+        time.sleep(.1)
+
     return p.poll()
 
 


### PR DESCRIPTION
Hello,

This is a fix for this super long ticket https://dev.yunohost.org/issues/654. After (long) investigations by @maniackcrudelis, we end up finding that add a `time.sleep(1)` solves the issue on his testing environment.

This PR had a timeout mecanism to make this approach a bit more robust.

This bug is critical for our CI.

**I haven't tested this PR yet, I'm too tired for that and need to sleep for work.**