### PR TITLE
log.SUCCESS Not Supported

### DIFF
--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -163,7 +163,6 @@ class TTYHandler(logging.StreamHandler):
         logging.NOTSET: 'white',
         logging.DEBUG: 'white',
         logging.INFO: 'cyan',
-        logging.SUCCESS: 'green',
         logging.WARNING: 'yellow',
         logging.ERROR: 'red',
         logging.CRITICAL: 'red',


### PR DESCRIPTION
AttributeError: 'module' object has no attribute 'SUCCESS'