### PR TITLE
Use ordered dict for the actionmap cache

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -526,7 +526,7 @@ class ActionsMap(object):
             # Read actions map from yaml file
             am_file = '%s/actionsmap/%s.yml' % (pkg.datadir, n)
             with open(am_file, 'r') as f:
-                actionsmaps[n] = yaml.load(f)
+                actionsmaps[n] = ordered_yaml_load(f)
 
             # at installation, cachedir might not exists
             if os.path.exists('%s/actionsmap/' % pkg.cachedir):


### PR DESCRIPTION
When trying to add an actionmap for `yunohost tools urlavailability domain path`, moulinette swapped the domain and path arguments (i.e. wanted to have `yunohost tools urlavailability path domain`) because of the way the cache is stored. This is pretty inconvenient because that's not a natural order for the argument.

I noticed that there were some inconsistency [here](https://github.com/YunoHost/moulinette/blob/6c200ad9c9ce889fe1e94497b9b9dbfcf9dc7f90/moulinette/actionsmap.py#L385-L399) between `pickle.load()` (unordered, "the default stuff") and `ordered_yaml_load()` (ordered, used in some weird cases ?). 

This is pretty nasty because right now we can't trust the order of the arguments requested/given ... i.e. if we have any command such as `yunohost category action arg1 arg2`, then nothing prevents moulinette from swapping arg1 and arg2 on some weird setups...

Then I realized than nothing prevents us to feed an ordered_dict to pickle when creating the cache (c.f. the one line fix).

Note that this also affects : 
- how things are displayed in all --help (i.e. it now uses the order of things in the actionmap instead of random order)(this is useful so that for instance all the cert-install, cert-renew, cert-status stays together) ;
- in which order missing required arguments are asked (see `yunohost user create`)
- **it might break existing commands that require two positional arguments if they got swapped...**