### PR TITLE
[fix] Correctly handle error 500

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -483,7 +483,6 @@ class HTTPErrorResponse(HTTPResponse):
 
 
 def error_to_response(error):
-
     """Convert a MoulinetteError to relevant HTTP response."""
     if error.errno == errno.EPERM:
         return HTTPForbiddenResponse(error.strerror)

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -387,6 +387,15 @@ class _ActionsMapPlugin(object):
             ret = self.actionsmap.process(arguments, timeout=30, route=_route)
         except MoulinetteError as e:
             raise error_to_response(e)
+        except Exception as e:
+            if isinstance(e, HTTPResponse):
+                raise e
+            import traceback
+            tb = traceback.format_exc()
+            logs = { "route": _route,
+                     "arguments": arguments,
+                     "traceback": tb }
+            return HTTPErrorResponse(json_encode(logs))
         else:
             return format_for_response(ret)
         finally:
@@ -474,6 +483,7 @@ class HTTPErrorResponse(HTTPResponse):
 
 
 def error_to_response(error):
+
     """Convert a MoulinetteError to relevant HTTP response."""
     if error.errno == errno.EPERM:
         return HTTPForbiddenResponse(error.strerror)


### PR DESCRIPTION
### Problem

At the moment, the moulinette does not properly handle exception when called with the API. This trigger an obscure "500 Internal Server Error" on the webadmin.

### Solution

Add an exception handling and feed the web admin with the details/traceback of what happened.

Related PR on Moulinette : https://github.com/YunoHost/yunohost-admin/pull/166