### PR TITLE
try to make ActionsMap._construct_parser code more readable

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -582,7 +582,7 @@ class ActionsMap(object):
                     continue
 
                 extra = argument_options.pop('extra')
-                arg_dest = (parser.add_argument(*names, **argument_options)).dest
+                arg_dest = parser.add_argument(*names, **argument_options).dest
                 self.extraparser.add_argument(tid, arg_dest, extra,
                                               validate_extra)
 

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -643,7 +643,7 @@ class ActionsMap(object):
 
                     try:
                         # Get action parser
-                        a_parser = category_parser.add_action_parser(action_name, tid, **action_options)
+                        action_parser = category_parser.add_action_parser(action_name, tid, **action_options)
                     except AttributeError:
                         # No parser for the action
                         continue
@@ -653,8 +653,8 @@ class ActionsMap(object):
                         continue
 
                     # Store action identifier and add arguments
-                    a_parser.set_defaults(_tid=tid)
-                    _add_arguments(tid, a_parser, arguments)
+                    action_parser.set_defaults(_tid=tid)
+                    _add_arguments(tid, action_parser, arguments)
                     _set_conf(category_parser)
 
         return top_parser

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -562,10 +562,10 @@ class ActionsMap(object):
 
         """
         # Get extra parameters
-        if not self.use_cache:
-            validate_extra = True
-        else:
+        if self.use_cache:
             validate_extra = False
+        else:
+            validate_extra = True
 
         # Instantiate parser
         #

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -603,6 +603,7 @@ class ActionsMap(object):
             # Set the global configuration to use for the parser.
             top_parser.set_global_conf(_global['configuration'])
 
+            # GLOBAL_SECTION = '_global'
             _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
                                _global['arguments'])
 

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -596,7 +596,8 @@ class ActionsMap(object):
                 actions = category_values.pop('actions')
 
                 # Get category parser
-                category_parser = top_parser.add_category_parser(category_name, **category_values)
+                category_parser = top_parser.add_category_parser(category_name,
+                                                                 **category_values)
 
                 # action_name is like "list" of "domain list"
                 # action_options are the values
@@ -606,7 +607,9 @@ class ActionsMap(object):
 
                     try:
                         # Get action parser
-                        action_parser = category_parser.add_action_parser(action_name, tid, **action_options)
+                        action_parser = category_parser.add_action_parser(action_name,
+                                                                          tid,
+                                                                          **action_options)
                     except AttributeError:
                         # No parser for the action
                         continue

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -609,7 +609,8 @@ class ActionsMap(object):
                     _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
                                    _global['arguments'])
 
-            # -- Parse categories
+            # category_name is stuff like "user", "domain", "hooks"...
+            # category_values is the values of this category (like actions)
             for category_name, category_values in actionsmap.items():
                 if "actions" not in category_values:
                     # Invalid category without actions

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -609,9 +609,8 @@ class ActionsMap(object):
 
             # -- Parse global arguments
             if 'arguments' in _global:
-                if hasattr(top_parser, "add_global_parser"):
-                    _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
-                                   _global['arguments'])
+                _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
+                               _global['arguments'])
 
             # category_name is stuff like "user", "domain", "hooks"...
             # category_values is the values of this category (like actions)

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -583,8 +583,7 @@ class ActionsMap(object):
 
                 extra = argument_options.pop('extra')
                 arg_dest = parser.add_argument(*names, **argument_options).dest
-                self.extraparser.add_argument(tid, arg_dest, extra,
-                                              validate_extra)
+                self.extraparser.add_argument(tid, arg_dest, extra, validate_extra)
 
         # Instantiate parser
         #

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -567,27 +567,6 @@ class ActionsMap(object):
         else:
             validate_extra = False
 
-        # Add arguments to the parser
-        def _add_arguments(tid, parser, arguments):
-            # parser is argparse._ArgumentGroup for top_parser
-            # or ExtendedArgumentParser for other cases
-            # or maybe something else?
-            for argument_name, argument_options in arguments.items():
-                # will adapt arguments name for cli or api context
-                names = top_parser.format_arg_names(str(argument_name),
-                                                    argument_options.pop('full', None))
-
-                if "type" in argument_options:
-                    argument_options['type'] = eval(argument_options['type'])
-
-                if "extra" not in argument_options:
-                    parser.add_argument(*names, **argument_options)
-                    continue
-
-                extra = argument_options.pop('extra')
-                argument_dest = parser.add_argument(*names, **argument_options).dest
-                self.extraparser.add_argument(tid, argument_dest, extra, validate_extra)
-
         # Instantiate parser
         #
         # this either returns:
@@ -634,7 +613,10 @@ class ActionsMap(object):
 
                     # Store action identifier and add arguments
                     action_parser.set_defaults(_tid=tid)
-                    _add_arguments(tid, action_parser, arguments)
+                    action_parser.add_arguments(arguments,
+                                                extraparser=self.extraparser,
+                                                format_arg_names=top_parser.format_arg_names,
+                                                validate_extra=validate_extra)
 
                     if 'configuration' in action_options:
                         configuration = action_options.pop('configuration')

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -570,7 +570,6 @@ class ActionsMap(object):
         # Add arguments to the parser
         def _add_arguments(tid, parser, arguments):
             for argument_name, argument_options in arguments.items():
-                print argument_options
                 names = top_parser.format_arg_names(str(argument_name),
                                                     argument_options.pop('full', None))
                 try:
@@ -578,14 +577,14 @@ class ActionsMap(object):
                 except:
                     pass
 
-                try:
-                    extra = argument_options.pop('extra')
-                    arg_dest = (parser.add_argument(*names, **argument_options)).dest
-                    self.extraparser.add_argument(tid, arg_dest, extra,
-                                                  validate_extra)
-                except KeyError:
-                    # No extra parameters
+                if "extra" not in argument_options:
                     parser.add_argument(*names, **argument_options)
+                    continue
+
+                extra = argument_options.pop('extra')
+                arg_dest = (parser.add_argument(*names, **argument_options)).dest
+                self.extraparser.add_argument(tid, arg_dest, extra,
+                                              validate_extra)
 
         # Instantiate parser
         #

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -610,22 +610,22 @@ class ActionsMap(object):
                                    _global['arguments'])
 
             # -- Parse categories
-            for cn, cp in actionsmap.items():
-                if "actions" not in cp:
+            for category_name, category_values in actionsmap.items():
+                if "actions" not in category_values:
                     # Invalid category without actions
                     logger.warning("no actions found in category '%s' in "
-                                   "namespace '%s'", cn, namespace)
+                                   "namespace '%s'", category_name, namespace)
                     continue
 
-                actions = cp.pop('actions')
+                actions = category_values.pop('actions')
 
                 # Get category parser
-                cat_parser = top_parser.add_category_parser(cn, **cp)
+                cat_parser = top_parser.add_category_parser(category_name, **category_values)
 
                 # -- Parse actions
                 for an, ap in actions.items():
                     args = ap.pop('arguments', {})
-                    tid = (namespace, cn, an)
+                    tid = (namespace, category_name, an)
 
                     if 'configuration' in ap:
                         conf = ap.pop('configuration')
@@ -643,7 +643,7 @@ class ActionsMap(object):
                         continue
                     except ValueError as e:
                         logger.warning("cannot add action (%s, %s, %s): %s",
-                                       namespace, cn, an, e)
+                                       namespace, category_name, an, e)
                         continue
 
                     # Store action identifier and add arguments

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -572,10 +572,9 @@ class ActionsMap(object):
             for argument_name, argument_options in arguments.items():
                 names = top_parser.format_arg_names(str(argument_name),
                                                     argument_options.pop('full', None))
-                try:
+
+                if "type" in argument_options:
                     argument_options['type'] = eval(argument_options['type'])
-                except:
-                    pass
 
                 if "extra" not in argument_options:
                     parser.add_argument(*names, **argument_options)

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -587,6 +587,10 @@ class ActionsMap(object):
                     parser.add_argument(*names, **argp)
 
         # Instantiate parser
+        #
+        # this either returns:
+        # * moulinette.interfaces.cli.ActionsMapParser
+        # * moulinette.interfaces.api.ActionsMapParser
         top_parser = self.parser_class(**kwargs)
 
         # namespace, actionsmap is a tuple where:

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -611,12 +611,6 @@ class ActionsMap(object):
             # category_name is stuff like "user", "domain", "hooks"...
             # category_values is the values of this category (like actions)
             for category_name, category_values in actionsmap.items():
-                if "actions" not in category_values:
-                    # Invalid category without actions
-                    logger.warning("no actions found in category '%s' in "
-                                   "namespace '%s'", category_name, namespace)
-                    continue
-
                 actions = category_values.pop('actions')
 
                 # Get category parser

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -587,7 +587,6 @@ class ActionsMap(object):
             top_parser.set_global_conf(_global['configuration'])
 
             if top_parser.has_global_parser():
-                # GLOBAL_SECTION = '_global'
                 top_parser.add_global_arguments(_global['arguments'])
 
             # category_name is stuff like "user", "domain", "hooks"...
@@ -605,13 +604,12 @@ class ActionsMap(object):
                     arguments = action_options.pop('arguments', {})
                     tid = (namespace, category_name, action_name)
 
-                    try:
-                        # Get action parser
-                        action_parser = category_parser.add_action_parser(action_name,
-                                                                          tid,
-                                                                          **action_options)
-                    except AttributeError:
-                        # No parser for the action
+                    # Get action parser
+                    action_parser = category_parser.add_action_parser(action_name,
+                                                                      tid,
+                                                                      **action_options)
+
+                    if action_parser is None:  # No parser for the action
                         continue
 
                     # Store action identifier and add arguments

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -609,8 +609,7 @@ class ActionsMap(object):
 
             if top_parser.has_global_parser():
                 # GLOBAL_SECTION = '_global'
-                _add_arguments(GLOBAL_SECTION, top_parser.global_parser,
-                                   _global['arguments'])
+                top_parser.add_global_arguments(_global['arguments'])
 
             # category_name is stuff like "user", "domain", "hooks"...
             # category_values is the values of this category (like actions)

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -569,22 +569,23 @@ class ActionsMap(object):
 
         # Add arguments to the parser
         def _add_arguments(tid, parser, arguments):
-            for argn, argp in arguments.items():
-                names = top_parser.format_arg_names(str(argn),
-                                                    argp.pop('full', None))
+            for argument_name, argument_options in arguments.items():
+                print argument_options
+                names = top_parser.format_arg_names(str(argument_name),
+                                                    argument_options.pop('full', None))
                 try:
-                    argp['type'] = eval(argp['type'])
+                    argument_options['type'] = eval(argument_options['type'])
                 except:
                     pass
 
                 try:
-                    extra = argp.pop('extra')
-                    arg_dest = (parser.add_argument(*names, **argp)).dest
+                    extra = argument_options.pop('extra')
+                    arg_dest = (parser.add_argument(*names, **argument_options)).dest
                     self.extraparser.add_argument(tid, arg_dest, extra,
                                                   validate_extra)
                 except KeyError:
                     # No extra parameters
-                    parser.add_argument(*names, **argp)
+                    parser.add_argument(*names, **argument_options)
 
         # Instantiate parser
         #

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -623,13 +623,14 @@ class ActionsMap(object):
                 # Get category parser
                 category_parser = top_parser.add_category_parser(category_name, **category_values)
 
-                # -- Parse actions
-                for an, ap in actions.items():
-                    args = ap.pop('arguments', {})
-                    tid = (namespace, category_name, an)
+                # action_name is like "list" of "domain list"
+                # action_options are the values
+                for action_name, action_options in actions.items():
+                    args = action_options.pop('arguments', {})
+                    tid = (namespace, category_name, action_name)
 
-                    if 'configuration' in ap:
-                        conf = ap.pop('configuration')
+                    if 'configuration' in action_options:
+                        conf = action_options.pop('configuration')
                         _set_conf = lambda p: p.set_conf(tid, conf)
 
                     else:
@@ -638,13 +639,13 @@ class ActionsMap(object):
 
                     try:
                         # Get action parser
-                        a_parser = category_parser.add_action_parser(an, tid, **ap)
+                        a_parser = category_parser.add_action_parser(action_name, tid, **action_options)
                     except AttributeError:
                         # No parser for the action
                         continue
                     except ValueError as e:
                         logger.warning("cannot add action (%s, %s, %s): %s",
-                                       namespace, category_name, an, e)
+                                       namespace, category_name, action_name, e)
                         continue
 
                     # Store action identifier and add arguments

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -581,8 +581,8 @@ class ActionsMap(object):
                     continue
 
                 extra = argument_options.pop('extra')
-                arg_dest = parser.add_argument(*names, **argument_options).dest
-                self.extraparser.add_argument(tid, arg_dest, extra, validate_extra)
+                argument_dest = parser.add_argument(*names, **argument_options).dest
+                self.extraparser.add_argument(tid, argument_dest, extra, validate_extra)
 
         # Instantiate parser
         #

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -603,9 +603,10 @@ class ActionsMap(object):
             # Set the global configuration to use for the parser.
             top_parser.set_global_conf(_global['configuration'])
 
-            # GLOBAL_SECTION = '_global'
-            _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
-                               _global['arguments'])
+            if top_parser.has_global_parser():
+                # GLOBAL_SECTION = '_global'
+                _add_arguments(GLOBAL_SECTION, top_parser.get_global_parser(),
+                                   _global['arguments'])
 
             # category_name is stuff like "user", "domain", "hooks"...
             # category_values is the values of this category (like actions)

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -626,14 +626,6 @@ class ActionsMap(object):
                     arguments = action_options.pop('arguments', {})
                     tid = (namespace, category_name, action_name)
 
-                    if 'configuration' in action_options:
-                        configuration = action_options.pop('configuration')
-                        _set_conf = lambda p: p.set_conf(tid, configuration)
-
-                    else:
-                        # No action configuration
-                        _set_conf = lambda p: False
-
                     try:
                         # Get action parser
                         action_parser = category_parser.add_action_parser(action_name, tid, **action_options)
@@ -648,6 +640,9 @@ class ActionsMap(object):
                     # Store action identifier and add arguments
                     action_parser.set_defaults(_tid=tid)
                     _add_arguments(tid, action_parser, arguments)
-                    _set_conf(category_parser)
+
+                    if 'configuration' in action_options:
+                        configuration = action_options.pop('configuration')
+                        category_parser.set_conf(tid, configuration)
 
         return top_parser

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -605,7 +605,7 @@ class ActionsMap(object):
 
             if top_parser.has_global_parser():
                 # GLOBAL_SECTION = '_global'
-                _add_arguments(GLOBAL_SECTION, top_parser.get_global_parser(),
+                _add_arguments(GLOBAL_SECTION, top_parser.global_parser,
                                    _global['arguments'])
 
             # category_name is stuff like "user", "domain", "hooks"...

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -602,14 +602,9 @@ class ActionsMap(object):
             # Retrieve global parameters
             _global = actionsmap.pop('_global', {})
 
-            # -- Parse global configuration
-            if 'configuration' in _global:
-                # Set global configuration
-                top_parser.set_global_conf(_global['configuration'])
+            top_parser.set_global_conf(_global['configuration'])
 
-            # -- Parse global arguments
-            if 'arguments' in _global:
-                _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
+            _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),
                                _global['arguments'])
 
             # category_name is stuff like "user", "domain", "hooks"...

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -569,7 +569,11 @@ class ActionsMap(object):
 
         # Add arguments to the parser
         def _add_arguments(tid, parser, arguments):
+            # parser is argparse._ArgumentGroup for top_parser
+            # or ExtendedArgumentParser for other cases
+            # or maybe something else?
             for argument_name, argument_options in arguments.items():
+                # will adapt arguments name for cli or api context
                 names = top_parser.format_arg_names(str(argument_name),
                                                     argument_options.pop('full', None))
 

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -626,12 +626,12 @@ class ActionsMap(object):
                 # action_name is like "list" of "domain list"
                 # action_options are the values
                 for action_name, action_options in actions.items():
-                    args = action_options.pop('arguments', {})
+                    arguments = action_options.pop('arguments', {})
                     tid = (namespace, category_name, action_name)
 
                     if 'configuration' in action_options:
-                        conf = action_options.pop('configuration')
-                        _set_conf = lambda p: p.set_conf(tid, conf)
+                        configuration = action_options.pop('configuration')
+                        _set_conf = lambda p: p.set_conf(tid, configuration)
 
                     else:
                         # No action configuration
@@ -650,7 +650,7 @@ class ActionsMap(object):
 
                     # Store action identifier and add arguments
                     a_parser.set_defaults(_tid=tid)
-                    _add_arguments(tid, a_parser, args)
+                    _add_arguments(tid, a_parser, arguments)
                     _set_conf(category_parser)
 
         return top_parser

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -589,8 +589,13 @@ class ActionsMap(object):
         # Instantiate parser
         top_parser = self.parser_class(**kwargs)
 
-        # Iterate over actions map namespaces
-        for n, actionsmap in actionsmaps.items():
+        # namespace, actionsmap is a tuple where:
+        #
+        # * namespace define the top "name", for us it will always be
+        #   "yunohost" and there well be only this one
+        # * actionsmap is the actual actionsmap that we care about
+        for namespace, actionsmap in actionsmaps.items():
+            print "n>>>", namespace
             # Retrieve global parameters
             _global = actionsmap.pop('_global', {})
 
@@ -610,7 +615,7 @@ class ActionsMap(object):
                 if "actions" not in cp:
                     # Invalid category without actions
                     logger.warning("no actions found in category '%s' in "
-                                   "namespace '%s'", cn, n)
+                                   "namespace '%s'", cn, namespace)
                     continue
 
                 actions = cp.pop('actions')
@@ -621,7 +626,7 @@ class ActionsMap(object):
                 # -- Parse actions
                 for an, ap in actions.items():
                     args = ap.pop('arguments', {})
-                    tid = (n, cn, an)
+                    tid = (namespace, cn, an)
 
                     if 'configuration' in ap:
                         conf = ap.pop('configuration')
@@ -639,7 +644,7 @@ class ActionsMap(object):
                         continue
                     except ValueError as e:
                         logger.warning("cannot add action (%s, %s, %s): %s",
-                                       n, cn, an, e)
+                                       namespace, cn, an, e)
                         continue
 
                     # Store action identifier and add arguments

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -620,7 +620,6 @@ class ActionsMap(object):
                                                 validate_extra=validate_extra)
 
                     if 'configuration' in action_options:
-                        configuration = action_options.pop('configuration')
-                        category_parser.set_conf(tid, configuration)
+                        category_parser.set_conf(tid, action_options['configuration'])
 
         return top_parser

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -595,7 +595,6 @@ class ActionsMap(object):
         #   "yunohost" and there well be only this one
         # * actionsmap is the actual actionsmap that we care about
         for namespace, actionsmap in actionsmaps.items():
-            print "n>>>", namespace
             # Retrieve global parameters
             _global = actionsmap.pop('_global', {})
 

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -621,7 +621,7 @@ class ActionsMap(object):
                 actions = category_values.pop('actions')
 
                 # Get category parser
-                cat_parser = top_parser.add_category_parser(category_name, **category_values)
+                category_parser = top_parser.add_category_parser(category_name, **category_values)
 
                 # -- Parse actions
                 for an, ap in actions.items():
@@ -638,7 +638,7 @@ class ActionsMap(object):
 
                     try:
                         # Get action parser
-                        a_parser = cat_parser.add_action_parser(an, tid, **ap)
+                        a_parser = category_parser.add_action_parser(an, tid, **ap)
                     except AttributeError:
                         # No parser for the action
                         continue
@@ -650,6 +650,6 @@ class ActionsMap(object):
                     # Store action identifier and add arguments
                     a_parser.set_defaults(_tid=tid)
                     _add_arguments(tid, a_parser, args)
-                    _set_conf(cat_parser)
+                    _set_conf(category_parser)
 
         return top_parser

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -603,6 +603,7 @@ class ActionsMap(object):
             # Retrieve global parameters
             _global = actionsmap.pop('_global', {})
 
+            # Set the global configuration to use for the parser.
             top_parser.set_global_conf(_global['configuration'])
 
             _add_arguments(GLOBAL_SECTION, top_parser.add_global_parser(),

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -632,10 +632,6 @@ class ActionsMap(object):
                     except AttributeError:
                         # No parser for the action
                         continue
-                    except ValueError as e:
-                        logger.warning("cannot add action (%s, %s, %s): %s",
-                                       namespace, category_name, action_name, e)
-                        continue
 
                     # Store action identifier and add arguments
                     action_parser.set_defaults(_tid=tid)

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -72,6 +72,9 @@ class BaseActionsMapParser(object):
         raise NotImplementedError("derived class '%s' must override this method" %
                                   self.__class__.__name__)
 
+    def has_global_parser(self):
+        return False
+
     def add_global_parser(self, **kwargs):
         """Add a parser for global arguments
 

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -539,9 +539,6 @@ class ExtendedArgumentParser(argparse.ArgumentParser):
         return queue
 
     def add_arguments(self, arguments, extraparser, format_arg_names=None, validate_extra=True):
-        # parser is argparse._ArgumentGroup for top_parser
-        # or ExtendedArgumentParser for other cases
-        # or maybe something else?
         for argument_name, argument_options in arguments.items():
             # will adapt arguments name for cli or api context
             names = format_arg_names(str(argument_name),
@@ -558,7 +555,6 @@ class ExtendedArgumentParser(argparse.ArgumentParser):
                 continue
 
             self.add_argument(*names, **argument_options)
-
 
     def _get_nargs_pattern(self, action):
         if action.nargs == argparse.PARSER and not action.required:

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -538,6 +538,28 @@ class ExtendedArgumentParser(argparse.ArgumentParser):
                 queue = list()
         return queue
 
+    def add_arguments(self, arguments, extraparser, format_arg_names=None, validate_extra=True):
+        # parser is argparse._ArgumentGroup for top_parser
+        # or ExtendedArgumentParser for other cases
+        # or maybe something else?
+        for argument_name, argument_options in arguments.items():
+            # will adapt arguments name for cli or api context
+            names = format_arg_names(str(argument_name),
+                                     argument_options.pop('full', None))
+
+            if "type" in argument_options:
+                argument_options['type'] = eval(argument_options['type'])
+
+            if "extra" in argument_options:
+                extra = argument_options.pop('extra')
+                argument_dest = self.add_argument(*names, **argument_options).dest
+                extraparser.add_argument(self.get_default("_tid"),
+                                         argument_dest, extra, validate_extra)
+                continue
+
+            self.add_argument(*names, **argument_options)
+
+
     def _get_nargs_pattern(self, action):
         if action.nargs == argparse.PARSER and not action.required:
             return '([-AO]*)'

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -548,7 +548,7 @@ class ActionsMapParser(BaseActionsMapParser):
             return [name.replace('--', '@', 1)]
         return [name.replace('-', '@', 1)]
 
-    def add_global_parser(self, **kwargs):
+    def get_global_parser(self, **kwargs):
         raise AttributeError("global arguments are not managed")
 
     def add_category_parser(self, name, **kwargs):

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -80,6 +80,24 @@ class _HTTPArgumentParser(object):
     def get_default(self, dest):
         return self._parser.get_default(dest)
 
+    def add_arguments(self, arguments, extraparser, format_arg_names=None, validate_extra=True):
+        for argument_name, argument_options in arguments.items():
+            # will adapt arguments name for cli or api context
+            names = format_arg_names(str(argument_name),
+                                     argument_options.pop('full', None))
+
+            if "type" in argument_options:
+                argument_options['type'] = eval(argument_options['type'])
+
+            if "extra" in argument_options:
+                extra = argument_options.pop('extra')
+                argument_dest = self.add_argument(*names, **argument_options).dest
+                extraparser.add_argument(self.get_default("_tid"),
+                                         argument_dest, extra, validate_extra)
+                continue
+
+            self.add_argument(*names, **argument_options)
+
     def add_argument(self, *args, **kwargs):
         action = self._parser.add_argument(*args, **kwargs)
 

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -548,9 +548,6 @@ class ActionsMapParser(BaseActionsMapParser):
             return [name.replace('--', '@', 1)]
         return [name.replace('-', '@', 1)]
 
-    def get_global_parser(self, **kwargs):
-        raise AttributeError("global arguments are not managed")
-
     def add_category_parser(self, name, **kwargs):
         return self
 

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -596,7 +596,7 @@ class ActionsMapParser(BaseActionsMapParser):
                 if len(keys) == 0:
                     raise ValueError("no valid api route found")
             else:
-                raise AttributeError("no api route for action '%s'" % name)
+                return None
 
         # Create and append parser
         parser = _HTTPArgumentParser()

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -235,7 +235,7 @@ class ActionsMapParser(BaseActionsMapParser):
 
         if top_parser:
             # Append each top parser action to the global group
-            glob = self.add_global_parser()
+            glob = self.get_global_parser()
             for action in top_parser._actions:
                 action.dest = SUPPRESS
                 glob._add_action(action)
@@ -252,7 +252,10 @@ class ActionsMapParser(BaseActionsMapParser):
             return [name, full]
         return [name]
 
-    def add_global_parser(self, **kwargs):
+    def has_global_parser(self):
+        return True
+
+    def get_global_parser(self, **kwargs):
         if not self._global_parser:
             self._global_parser = self._parser.add_argument_group(
                 "global arguments")

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -231,14 +231,15 @@ class ActionsMapParser(BaseActionsMapParser):
 
         self._parser = parser or ExtendedArgumentParser()
         self._subparsers = self._parser.add_subparsers(**subparser_kwargs)
-        self._global_parser = parent._global_parser if parent else None
+        self.global_parser = parent.global_parser if parent else None
 
         if top_parser:
+            self.global_parser = self._parser.add_argument_group("global arguments")
+
             # Append each top parser action to the global group
-            glob = self.get_global_parser()
             for action in top_parser._actions:
                 action.dest = SUPPRESS
-                glob._add_action(action)
+                self.global_parser._add_action(action)
 
     # Implement virtual properties
 
@@ -254,12 +255,6 @@ class ActionsMapParser(BaseActionsMapParser):
 
     def has_global_parser(self):
         return True
-
-    def get_global_parser(self, **kwargs):
-        if not self._global_parser:
-            self._global_parser = self._parser.add_argument_group(
-                "global arguments")
-        return self._global_parser
 
     def add_category_parser(self, name, category_help=None, **kwargs):
         """Add a parser for a category

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -288,6 +288,15 @@ class ActionsMapParser(BaseActionsMapParser):
                                            deprecated=deprecated,
                                            deprecated_alias=deprecated_alias)
 
+    def add_global_arguments(self, arguments):
+        for argument_name, argument_options in arguments.items():
+            # will adapt arguments name for cli or api context
+            names = self.format_arg_names(str(argument_name),
+                                          argument_options.pop('full', None))
+
+            self.global_parser.add_argument(*names, **argument_options)
+
+
     def parse_args(self, args, **kwargs):
         try:
             ret = self._parser.parse_args(args)

--- a/moulinette/utils/filesystem.py
+++ b/moulinette/utils/filesystem.py
@@ -9,6 +9,7 @@ from moulinette.core import MoulinetteError
 
 # Files & directories --------------------------------------------------
 
+
 def read_file(file_path):
     """
     Read a regular text file
@@ -93,6 +94,7 @@ def write_to_file(file_path, data, file_mode="w"):
         raise MoulinetteError(errno.EIO,
                               m18n.g('error_writing_file',
                                      file=file_path, error=str(e)))
+
 
 def append_to_file(file_path, data):
     """

--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -106,7 +106,7 @@ def call_async_output(args, callback, **kwargs):
 # Call multiple commands -----------------------------------------------
 
 def run_commands(cmds, callback=None, separate_stderr=False, shell=True,
-                  **kwargs):
+                 **kwargs):
     """Run multiple commands with error management
 
     Run a list of commands and allow to manage how to treat errors either


### PR DESCRIPTION
I recommend to read this commits by commits as a lot of things have been modified.

I've tried to make "one action per commit" to make the workflow more understandable.

If that's too much at once we can try to split into several batch of commits.

Normally I haven't break anything (yunohost-{cli,api} works for me with this refactoring in ynh-dev).

Still, it's not perfect, the code makes a lot way too much interconnections and is full of magic and "out of nowhere" stuff so we'll have to move step by step and this is a first one.

I'm still impressed by all the things that moulinette does, this isn't a trivial problem.