### PR TITLE
[enh] Show description of command in --help

### DIFF
--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -267,7 +267,10 @@ class ActionsMapParser(BaseActionsMapParser):
             A new ActionsMapParser object for the category
 
         """
-        parser = self._subparsers.add_parser(name, help=category_help, **kwargs)
+        parser = self._subparsers.add_parser(name,
+                                             description=category_help,
+                                             help=category_help,
+                                             **kwargs)
         return self.__class__(self, parser, {
             'title': "subcommands", 'required': True
         })
@@ -284,6 +287,7 @@ class ActionsMapParser(BaseActionsMapParser):
         """
         parser = self._subparsers.add_parser(name,
                                              type_="subcategory",
+                                             description=subcategory_help,
                                              help=subcategory_help,
                                              **kwargs)
         return self.__class__(self, parser, {
@@ -306,6 +310,7 @@ class ActionsMapParser(BaseActionsMapParser):
         return self._subparsers.add_parser(name,
                                            type_="action",
                                            help=action_help,
+                                           description=action_help,
                                            deprecated=deprecated,
                                            deprecated_alias=deprecated_alias)
 


### PR DESCRIPTION
### Problem

Right now it's a bit frustrating that, when you forgot what a not-so-trivial command does, type `yunohost foo bar --help` but this doesn't tell you anything about what the command does ! To get the info, you need to run `yunohost foo --help` and read the help for argument `bar`.

### Solution

Add a description field for categories, subcategories and actions.

Result : 

![capture du 2017-08-06 02-51-09](https://user-images.githubusercontent.com/4533074/28999724-f9f0bb94-7a52-11e7-9341-5f363c5d7ef4.png)
