### PR TITLE
[enh] Simpler lock system

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Depends: ${misc:Depends}, ${python:Depends},
     python-bottle (>= 0.12),
     python-gnupg,
     python-gevent-websocket,
-    python-argcomplete
+    python-argcomplete,
+    python-psutil
 Replaces: yunohost-cli
 Breaks: yunohost-cli
 Description: prototype interfaces with ease in Python

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -496,7 +496,6 @@ class MoulinetteLock(object):
 
         return lock_pid
 
-
     def _is_son_of_locked(self):
 
         lock_pid = self._lock_PID()
@@ -506,7 +505,7 @@ class MoulinetteLock(object):
 
         parent = psutil.Process()
         # While this is not the very first process
-        while parent.parent() != None:
+        while parent.parent() is not None:
             # If parent PID is the lock, the yes! we are a son of the process
             # with the lock...
             if parent.ppid() == int(lock_pid):

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -430,7 +430,6 @@ class MoulinetteLock(object):
         self._lockfile = '/var/run/moulinette_%s.lock' % namespace
         self._stale_checked = False
         self._locked = False
-        self._bypass = False
 
     def acquire(self):
         """Attempt to acquire the lock for the moulinette instance
@@ -443,10 +442,6 @@ class MoulinetteLock(object):
         start_time = time.time()
 
         while True:
-            if 'BYPASS_LOCK' in os.environ and os.environ['BYPASS_LOCK'] == 'yes':
-                self._bypass = True
-                break
-
             lock_pid = self._lock_PID()
 
             if lock_pid is None:
@@ -477,9 +472,7 @@ class MoulinetteLock(object):
 
         """
         if self._locked:
-            if not self._bypass:
-                os.unlink(self._lockfile)
-
+            os.unlink(self._lockfile)
             logger.debug('lock has been released')
             self._locked = False
 

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -152,10 +152,6 @@ class BaseActionsMapParser(object):
             namespace = argparse.Namespace()
         namespace._tid = tid
 
-        # Check lock
-        if not self.get_conf(tid, 'lock'):
-            os.environ['BYPASS_LOCK'] = 'yes'
-
         # Perform authentication if needed
         if self.get_conf(tid, 'authenticate'):
             auth_conf, cls = self.get_conf(tid, 'authenticator')

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -634,9 +634,6 @@ class ActionsMapParser(BaseActionsMapParser):
             raise MoulinetteError(errno.EINVAL, m18n.g('error_see_log'))
         ret = argparse.Namespace()
 
-        if not self.get_conf(tid, 'lock'):
-            os.environ['BYPASS_LOCK'] = 'yes'
-
         # Perform authentication if needed
         if self.get_conf(tid, 'authenticate'):
             # TODO: Clean this hard fix and find a way to set an authenticator


### PR DESCRIPTION
### Problem

Commands like `yunohost service regen-conf` needs to indirectly call daughter `yunohost` commands (e.g. `yunohost domain list` in hooks for instance). However, the normal behavior in the moulinette is that you cannot run multiple `yunohost` commands at the same time (c.f. lock mechanism). Right now, commands that need to be able to call other `yunohost` commands in their hooks needs to have `lock: false` in the actionsmap (such that the daughters can take the lock). This can be seen as a bit counterintuitive and overcomplicated.

### Solution

Before trying to acquire the lock, check if the parent or grand-parent or grand-grand-parent (and so on) has the lock. If so, ignore the lock mechanism.