### PR TITLE
Allow to give lock to multiple processes

### DIFF
--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -443,10 +443,10 @@ class MoulinetteLock(object):
 
         while True:
 
-            if self._is_son_of_locked():
-                return
-
             lock_pids = self._lock_PIDs()
+
+            if self._is_son_of(lock_pids):
+                return
 
             if lock_pids == []:
                 self._lock()
@@ -504,8 +504,7 @@ class MoulinetteLock(object):
 
         return lock_pids
 
-    def _is_son_of_locked(self):
-        lock_pids = self._lock_PIDs()
+    def _is_son_of(self, lock_pids):
 
         if lock_pids == []:
             return False
@@ -515,9 +514,9 @@ class MoulinetteLock(object):
 
         # While there is a parent... (e.g. init has no parent)
         while parent is not None:
-            # If parent PID is the lock, the yes! we are a son of the process
+            # If parent PID is the lock, then yes! we are a son of the process
             # with the lock...
-            if parent.ppid() in lock_pids:
+            if parent.pid in lock_pids:
                 return True
             # Otherwise, try 'next' parent
             parent = parent.parent()

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -442,6 +442,10 @@ class MoulinetteLock(object):
         start_time = time.time()
 
         while True:
+
+            if self._is_son_of_locked():
+                return
+
             lock_pid = self._lock_PID()
 
             if lock_pid is None:
@@ -517,7 +521,7 @@ class MoulinetteLock(object):
         return False
 
     def __enter__(self):
-        if not self._locked and not self._is_son_of_locked():
+        if not self._locked:
             self.acquire()
         return self
 

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -502,9 +502,11 @@ class MoulinetteLock(object):
         if lock_pid is None:
             return False
 
+        # Start with self
         parent = psutil.Process()
-        # While this is not the very first process
-        while parent.parent() is not None:
+
+        # While there is a parent... (e.g. init has no parent)
+        while parent is not None:
             # If parent PID is the lock, the yes! we are a son of the process
             # with the lock...
             if parent.ppid() == int(lock_pid):


### PR DESCRIPTION
### Problem

We want to be able to manage several locks. Also a command waiting to acquire the lock should keep checking if one of its parent got it in the meantime.

This is motivated by https://github.com/YunoHost/yunohost/pull/367

### Solution

The lock file can now contain several lock (on separate lines) and keep checking in `acquire()` if one of its parent got the lock (instead of just once in `__enter__()`).

### Validation

- [x] Principle agreement 1/2 : ljf
- [x] Quick review 1/1 : ljf
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1? :
