### PR TITLE
[enh] Lazy-load some modules to improve performances

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -469,10 +469,13 @@ class ActionsMap(object):
 
         # Lock the moulinette for the namespace
         with MoulinetteLock(namespace, timeout):
+            start = time()
             try:
                 mod = __import__('%s.%s' % (namespace, category),
                                  globals=globals(), level=0,
                                  fromlist=[func_name])
+                logger.debug('loading python module %s took %.3fs',
+                             '%s.%s' % (namespace, category), time() - start)
                 func = getattr(mod, func_name)
             except (AttributeError, ImportError):
                 logger.exception("unable to load function %s.%s",
@@ -495,7 +498,7 @@ class ActionsMap(object):
                     return func(**arguments)
                 finally:
                     stop = time()
-                    logger.debug('action [%s] ended after %.3fs',
+                    logger.debug('action [%s] executed in %.3fs',
                                  log_id, stop - start)
 
     @staticmethod

--- a/moulinette/utils/network.py
+++ b/moulinette/utils/network.py
@@ -1,5 +1,4 @@
 import errno
-import requests
 import json
 
 from moulinette import m18n
@@ -17,6 +16,7 @@ def download_text(url, timeout=30, expected_status_code=200):
         expected_status_code -- Status code expected from the request. Can be
         None to ignore the status code.
     """
+    import requests  # lazy loading this module for performance reasons
     # Assumptions
     assert isinstance(url, str)
 


### PR DESCRIPTION
While troubleshooting performance issues on yunohost I found out that some package imports were very slow and I think loading time is valuable information for debugging.

This PR makes this information visible when using `--debug` command line switch.
I also moved a slow import of module *requests*. Although I'm not sure this one currently improves perfs, it may be the case in the future.