### PR TITLE
[fix] Display the date in a correct format

### DIFF
--- a/moulinette/utils/serialize.py
+++ b/moulinette/utils/serialize.py
@@ -25,7 +25,7 @@ class JSONExtendedEncoder(JSONEncoder):
                 hasattr(o, '__iter__') and hasattr(o, 'next')):
             return list(o)
 
-        # Convert compatible containers into list
+        # Display the date in its iso format ISO-8601 Internet Profile (RFC 3339)
         if isinstance(o, datetime.datetime) or isinstance(o, datetime.date):
             return o.isoformat()
 

--- a/moulinette/utils/serialize.py
+++ b/moulinette/utils/serialize.py
@@ -27,7 +27,7 @@ class JSONExtendedEncoder(JSONEncoder):
 
         # Convert compatible containers into list
         if isinstance(o, datetime.datetime) or isinstance(o, datetime.date):
-            return str(o)
+            return o.isoformat()
 
         # Return the repr for object that json can't encode
         logger.warning('cannot properly encode in JSON the object %s, '

--- a/moulinette/utils/serialize.py
+++ b/moulinette/utils/serialize.py
@@ -1,5 +1,6 @@
 import logging
 from json.encoder import JSONEncoder
+import datetime
 
 logger = logging.getLogger('moulinette.utils.serialize')
 
@@ -23,6 +24,10 @@ class JSONExtendedEncoder(JSONEncoder):
         if isinstance(o, set) or (
                 hasattr(o, '__iter__') and hasattr(o, 'next')):
             return list(o)
+
+        # Convert compatible containers into list
+        if isinstance(o, datetime.datetime) or isinstance(o, datetime.date):
+            return str(o)
 
         # Return the repr for object that json can't encode
         logger.warning('cannot properly encode in JSON the object %s, '


### PR DESCRIPTION
### Problem

The date is send in python format, not good for a Web API
https://cloud.githubusercontent.com/assets/41827/16403714/5501e2a4-3cf8-11e6-8c2e-a77d57ab5a7f.png

### Solution

Display the date correctly, in a usable format

### How to test
This PR use date: https://github.com/YunoHost/yunohost/pull/165 
The webadmin PR associated is : https://github.com/YunoHost/yunohost-admin/pull/130

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 