### PR TITLE
[mod] execute async consumers in the main process

### DIFF
--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -81,14 +81,23 @@ def call_async_output(args, callback, **kwargs):
     if separate_stderr:
         stderr_reader, stderr_consum = async_file_reading(p.stderr, callback[1])
         while not stdout_reader.eof() and not stderr_reader.eof():
+            while not stdout_consum.empty() or not stderr_consum.empty():
+                # alternate between the 2 consumers to avoid desynchronisation
+                # this way is not 100% perfect but should do it
+                stdout_consum.process_next_line()
+                stderr_consum.process_next_line()
             time.sleep(.1)
         stderr_reader.join()
-        stderr_consum.join()
+        # clear the queues
+        stdout_consum.process_current_queue()
+        stderr_consum.process_current_queue()
     else:
         while not stdout_reader.eof():
+            stdout_consum.process_current_queue()
             time.sleep(.1)
     stdout_reader.join()
-    stdout_consum.join()
+    # clear the queue
+    stdout_consum.process_current_queue()
 
     # on slow hardware, in very edgy situations it is possible that the process
     # isn't finished just after having closed stdout and stderr, so we wait a


### PR DESCRIPTION
This is needed for the config-panel.

The problem that is solved is that the callback given to hook_exec were executed in another process, thus I couldn't modify the closure on the main process here https://github.com/YunoHost/yunohost/blob/165e9bc63d3d92ee9a6dcf244e95f848d212ea19/src/yunohost/app.py#L1471 https://github.com/YunoHost/yunohost/blob/165e9bc63d3d92ee9a6dcf244e95f848d212ea19/src/yunohost/app.py#L1477 since it was executed in another process.

To solve this, instead of switching everything to threads and maybe break things in a weird way, I've just put back the consumer responsible for calling the callbacks in the main process instead of putting it into a fork.

The resulting API is not especially pretty but that should do it. 

I've checked and this stream.py code is only executed in this `call_async_output` function so we should be safe.

And this works for the api too.

If you wish to understand better this part of the code don't hesitate to ask me on IRC, concurrency can be tricky.