### PR TITLE
[fix] sometime we get an empty string

### DIFF
--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -500,7 +500,7 @@ class MoulinetteLock(object):
             lock_pids = f.read().strip().split('\n')
 
         # Make sure to convert those pids to integers
-        lock_pids = [int(pid) for pid in lock_pids]
+        lock_pids = [int(pid) for pid in lock_pids if pid.strip() != '']
 
         return lock_pids
 


### PR DESCRIPTION
Error:

```
Setting up yunohost (3.0.0.1+201806221219) ... 
Regenerating configuration, this might take a while... 
Traceback (most recent call last): 
  File "/usr/bin/yunohost", line 213, in <module> 
    timeout=opts.timeout, 
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 136, in cli 
    moulinette.run(args, output_as=output_as, password=password, timeout=timeout) 
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 390, in run 
    ret = self.actionsmap.process(args, timeout=timeout) 
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 471, in process 
    with MoulinetteLock(namespace, timeout): 
  File "/usr/lib/python2.7/dist-packages/moulinette/core.py", line 528, in __enter__ 
    self.acquire() 
  File "/usr/lib/python2.7/dist-packages/moulinette/core.py", line 446, in acquire 
    lock_pids = self._lock_PIDs() 
  File "/usr/lib/python2.7/dist-packages/moulinette/core.py", line 503, in _lock_PIDs 
    lock_pids = [int(pid) for pid in lock_pids] 
ValueError: invalid literal for int() with base 10: ''
```

It's probably due to an empty file.