### PR TITLE
Dont crash on failed to format translation string

### DIFF
--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -89,13 +89,20 @@ class Translator(object):
 
         """
         if key in self._translations.get(self.locale, {}):
-            return self._translations[self.locale][key].encode('utf-8').format(*args, **kwargs)
+            try:
+                return self._translations[self.locale][key].encode('utf-8').format(*args, **kwargs)
+            except KeyError as e:
+                logger.warning("Failed to format translated string '%s' with error: %s" % (key, e))
 
         if self.default_locale != self.locale and key in self._translations.get(self.default_locale, {}):
             logger.info("untranslated key '%s' for locale '%s'",
                         key, self.locale)
 
-            return self._translations[self.default_locale][key].encode('utf-8').format(*args, **kwargs)
+            try:
+                return self._translations[self.default_locale][key].encode('utf-8').format(*args, **kwargs)
+            except KeyError as e:
+                logger.warning("Failed to format translatable string '%s' with error: %s" % (key, e))
+                return key
 
         logger.exception("unable to retrieve key '%s' for default locale '%s'",
                          key, self.default_locale)

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -104,7 +104,7 @@ class Translator(object):
                 return self._translations[self.default_locale][key].encode('utf-8').format(*args, **kwargs)
             except KeyError as e:
                 logger.exception("Failed to format translatable string '%s' with error: %s" % (key, e))
-                return key
+                return self._translations[self.locale][key].encode('utf-8')
 
         logger.exception("unable to retrieve key '%s' for default locale '%s'",
                          key, self.default_locale)

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -92,7 +92,7 @@ class Translator(object):
             try:
                 return self._translations[self.locale][key].encode('utf-8').format(*args, **kwargs)
             except KeyError as e:
-                logger.warning("Failed to format translated string '%s' with error: %s" % (key, e))
+                logger.exception("Failed to format translated string '%s' with error: %s" % (key, e))
 
         if self.default_locale != self.locale and key in self._translations.get(self.default_locale, {}):
             logger.info("untranslated key '%s' for locale '%s'",
@@ -101,7 +101,7 @@ class Translator(object):
             try:
                 return self._translations[self.default_locale][key].encode('utf-8').format(*args, **kwargs)
             except KeyError as e:
-                logger.warning("Failed to format translatable string '%s' with error: %s" % (key, e))
+                logger.exception("Failed to format translatable string '%s' with error: %s" % (key, e))
                 return key
 
         logger.exception("unable to retrieve key '%s' for default locale '%s'",

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -88,13 +88,15 @@ class Translator(object):
             - key -- The key to translate
 
         """
+        failed_to_format = False
         if key in self._translations.get(self.locale, {}):
             try:
                 return self._translations[self.locale][key].encode('utf-8').format(*args, **kwargs)
             except KeyError as e:
                 logger.exception("Failed to format translated string '%s' with error: %s" % (key, e))
+                failed_to_format = True
 
-        if self.default_locale != self.locale and key in self._translations.get(self.default_locale, {}):
+        if failed_to_format or (self.default_locale != self.locale and key in self._translations.get(self.default_locale, {})):
             logger.info("untranslated key '%s' for locale '%s'",
                         key, self.locale)
 


### PR DESCRIPTION
Fix the describe situation here https://github.com/YunoHost/yunohost/pull/512#discussion_r207753553

Tested in yunohost-tools-shell.

```
In [1]: m18n.n('app_location_unavailable')
Out[1]: 'This url is not available or conflicts with the already installed app(s):\n{apps:s}'
```

For some reason warning won't appear in yunohost shell :C 