### PR TITLE
Convert bool-like string arguments to actual bool

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -402,6 +402,14 @@ class _ActionsMapPlugin(object):
             - arguments -- A dict of arguments for the route
 
         """
+
+        # Convert POST arguments to boolean if they look like one...
+        for k, v in arguments.items():
+            if v.lower() == "true":
+                arguments[k] = True
+            elif v.lower() == "false":
+                arguments[k] = False
+
         try:
             ret = self.actionsmap.process(arguments, timeout=30, route=_route)
         except MoulinetteError as e:


### PR DESCRIPTION
### The problem

I need to be able to send a boolean argument '`force':True` (equivalent to `--force`) from the webadmin in the context of a POST request.

However, turns out that transmitting booleans in POST data is [not 100% trivial since only strings are transmitted anyway](https://stackoverflow.com/questions/3654454/boolean-variables-posted-through-ajax-being-treated-as-strings-in-server-side). So far we did not need such a thing...

### Proposed solution

I could do some dirty hack in my command API but that wouldnt be pretty for CLI users ... So instead I propose this fix were, if an arg looks like a boolean (i.e. `"true"` or `"false"`) it is converted to `True/False`