### PR TITLE
Allow to add comments to parameters

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -84,6 +84,25 @@ class _ExtraParameter(object):
         return value
 
 
+class CommentParameter(_ExtraParameter):
+    name = "comment"
+    skipped_iface = ['api']
+
+    def __call__(self, message, arg_name, arg_value):
+        return msignals.display(m18n.n(message))
+
+    @classmethod
+    def validate(klass, value, arg_name):
+        # Deprecated boolean or empty string
+        if isinstance(value, bool) or (isinstance(value, str) and not value):
+            logger.warning("expecting a string for extra parameter '%s' of "
+                           "argument '%s'", klass.name, arg_name)
+            value = arg_name
+        elif not isinstance(value, str):
+            raise TypeError("parameter value must be a string, got %r"
+                            % value)
+        return value
+
 class AskParameter(_ExtraParameter):
     """
     Ask for the argument value if possible and needed.
@@ -215,8 +234,8 @@ The list of available extra parameters classes. It will keep to this list
 order on argument parsing.
 
 """
-extraparameters_list = [AskParameter, PasswordParameter, RequiredParameter,
-                        PatternParameter]
+extraparameters_list = [CommentParameter, AskParameter, PasswordParameter, 
+                        RequiredParameter, PatternParameter]
 
 # Extra parameters argument Parser
 


### PR DESCRIPTION
### Problem

Related to https://github.com/YunoHost/yunohost/pull/196, it would be nice from a UX point of view to inform the admin/user about the constrain on the password rather than coldly refusing a password after it has been given (probably cancelling the whole command, then the user needs to reanswer every argument)

More generally, there are several case where we might want to add a comment to clarify what is asked. For instance, during the postintall, it may be good to have a comment explaining what is the Main domain and that it can be changed later for instance.

### Solution

Allow arguments in the actionmap to specify a string key corresponding to a comment that shall be displayed before asking the argument.

For instance, we may have : 

```
                -n:
                    full: --new-password
                    extra:
                        password: ask_new_admin_password
                        pattern: *pattern_password
                        required: True
                        comment: comment_about_admin_password_strengt
```

which may produce : 

```
# yunohost tools adminpw
Administration password: 
You are defining a new administration password. Beware that you password should be at least 8 characters - though it is good practice to use longer password (passphrases) and/or to use various kind of characters.
New administration password: 
```