### PR TITLE
Fix 'force' semantics in 'utils.filesystem.mkdir'

### DIFF
--- a/moulinette/utils/filesystem.py
+++ b/moulinette/utils/filesystem.py
@@ -196,7 +196,13 @@ def mkdir(path, mode=0777, parents=False, uid=None, gid=None, force=False):
                 return
 
     # Create directory and set permissions
-    os.mkdir(path, mode)
+    try:
+        os.mkdir(path, mode)
+    except OSError:
+        # mimic Python3.2+ os.makedirs exist_ok behaviour
+        if not force or not os.path.isdir(path):
+            raise
+
     if uid is not None or gid is not None:
         chown(path, uid, gid)
 


### PR DESCRIPTION
## Problem

In `utils.filesystem.mkdir`, the `force` argument is intended to enforce directory ownership / mode even if the target path already exists. However, the current implementation calls `os.mkdir` which raises `OSError` if the target path exists.

## Proposed solution

Mimic Python 3.2+ [os.makedirs](https://github.com/python/cpython/blob/52dee687af3671a31f63d6432de0d9ef370fd7b0/Lib/os.py#L196) `exist_ok` behaviour when creating the leaf.
This is a temporary patch waiting for a migration to Python 3.

## Status

Ready for review.

## Context

Problem identified in combination with `yunohost user ssh add-key` called when `$HOME/.ssh/authorized_keys` doesn't exit but `$HOME/.ssh` does. The [yunohost code](https://github.com/YunoHost/yunohost/blob/stretch-unstable/src/yunohost/ssh.py#L96) correctly calls `mkdir` with `force=True` but fails because of the problem addressed by this PR.