### PR TITLE
Fix coding style

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -230,6 +230,7 @@ class RequiredParameter(_ExtraParameter):
                             % value)
         return value
 
+
 """
 The list of available extra parameters classes. It will keep to this list
 order on argument parsing.

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -103,6 +103,7 @@ class CommentParameter(_ExtraParameter):
                             % value)
         return value
 
+
 class AskParameter(_ExtraParameter):
     """
     Ask for the argument value if possible and needed.
@@ -234,7 +235,7 @@ The list of available extra parameters classes. It will keep to this list
 order on argument parsing.
 
 """
-extraparameters_list = [CommentParameter, AskParameter, PasswordParameter, 
+extraparameters_list = [CommentParameter, AskParameter, PasswordParameter,
                         RequiredParameter, PatternParameter]
 
 # Extra parameters argument Parser

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import re
-import os
 import errno
 import logging
 import argparse

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
 import re
 import errno
 import logging

--- a/moulinette/utils/filesystem.py
+++ b/moulinette/utils/filesystem.py
@@ -7,7 +7,6 @@ import grp
 from pwd import getpwnam
 
 from moulinette import m18n
-from moulinette.globals import CACHE_DIR
 from moulinette.core import MoulinetteError
 
 # Files & directories --------------------------------------------------

--- a/moulinette/utils/log.py
+++ b/moulinette/utils/log.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-# import all constant because other modules tries to important them from this
+# import all constants because other modules try to import them from this
 # module because SUCCESS is defined in this module
 from logging import (addLevelName, setLoggerClass, Logger, getLogger, NOTSET,
                      DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -60,13 +60,13 @@ def call_async_output(args, callback, **kwargs):
             raise ValueError('%s argument not allowed, '
                              'it will be overridden.' % a)
 
-    if "stdinfo" in kwargs and kwargs["stdinfo"] != None:
+    if "stdinfo" in kwargs and kwargs["stdinfo"] is not None:
         assert len(callback) == 3
         stdinfo = kwargs.pop("stdinfo")
         os.mkfifo(stdinfo, 0600)
         # Open stdinfo for reading (in a nonblocking way, i.e. even
         # if command does not write in the stdinfo pipe...)
-        stdinfo_f = os.open(stdinfo, os.O_RDONLY|os.O_NONBLOCK)
+        stdinfo_f = os.open(stdinfo, os.O_RDONLY | os.O_NONBLOCK)
     else:
         kwargs.pop("stdinfo")
         stdinfo = None

--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -1,9 +1,6 @@
-import errno
 import time
 import subprocess
 import os
-
-from moulinette.core import MoulinetteError
 
 # This import is unused in this file. It will be deleted in future (W0611 PEP8),
 # but for the momment we keep it due to yunohost moulinette script that used


### PR DESCRIPTION
## Problem

The Travis-CI build fails for coding style reasons (first occurence quickly found is build [#278](https://travis-ci.org/YunoHost/moulinette/builds/419280251)). Some modules import unnecessary symbols.

## Proposed solution

Fix coding style according to PEP8. Remove unused imports except for those explicitly marked as voluntary.

## Status

Changes to make the CI build work are trivial and in principle harmless. Removal of unused imports may break client code (that shouldn't be) relying on them. Didn't check thoroughly for module import side effects within the `moulinette` code itself but doesn't seem to be the case. Ready for review.