### PR TITLE
Add possiblity to get attribute name of conflict in LDAP

### DIFF
--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -260,6 +260,4 @@ class Authenticator(BaseAuthenticator):
                 continue
             else:
                 return (attr, value)
-                logger.info("attribute '%s' with value '%s' is not unique",
-                            attr, value)
         return None

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -234,13 +234,31 @@ class Authenticator(BaseAuthenticator):
             Boolean | MoulinetteError
 
         """
+        attr_found = self.get_conflict(value_dict)
+        if attr_found:
+            logger.info("attribute '%s' with value '%s' is not unique",
+                        attr_found[0], attr_found[1])
+            raise MoulinetteError(errno.EEXIST,
+                                    m18n.g('ldap_attribute_already_exists',
+                                            attribute=attr_found[0], value=attr_found[1]))
+        return True
+
+    def get_conflict(self, value_dict, base_dn=None):
+        """
+        Check uniqueness of values
+
+        Keyword arguments:
+            value_dict -- Dictionnary of attributes/values to check
+
+        Returns:
+            None | list with Fist conflict attribute name and value
+
+        """
         for attr, value in value_dict.items():
-            if not self.search(filter=attr + '=' + value):
+            if not self.search(base=base_dn, filter=attr + '=' + value):
                 continue
             else:
+                return (attr, value)
                 logger.info("attribute '%s' with value '%s' is not unique",
                             attr, value)
-                raise MoulinetteError(errno.EEXIST,
-                                      m18n.g('ldap_attribute_already_exists',
-                                             attribute=attr, value=value))
-        return True
+        return None

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -239,8 +239,9 @@ class Authenticator(BaseAuthenticator):
             logger.info("attribute '%s' with value '%s' is not unique",
                         attr_found[0], attr_found[1])
             raise MoulinetteError(errno.EEXIST,
-                                    m18n.g('ldap_attribute_already_exists',
-                                            attribute=attr_found[0], value=attr_found[1]))
+                                  m18n.g('ldap_attribute_already_exists',
+                                         attribute=attr_found[0],
+                                         value=attr_found[1]))
         return True
 
     def get_conflict(self, value_dict, base_dn=None):


### PR DESCRIPTION
# Problem

- When we call the function `validate_uniqueness` we can't know if there are a conflict we don't know which attribute have generate a conflict and with which object we have a conflict.
- We can't manage the error with the function which call `validate_uniqueness`. Result is that if there are a conflict the user just see a message "Attribute '{attribute}' already exists with value '{value}'" but the user might not know the meaning of the attribute name.

# Solution

- Create a function `get_conflict` which just return the name of the attribute and it value if there are a conflict.
