### PR TITLE
Make sure `gpg.encrypt` actually does something

### DIFF
--- a/moulinette/authenticators/__init__.py
+++ b/moulinette/authenticators/__init__.py
@@ -138,9 +138,13 @@ class BaseAuthenticator(object):
         """Store a session and its associated password"""
         gpg = gnupg.GPG()
         gpg.encoding = 'utf-8'
+
+        # Encrypt the password using the session hash
+        s = str(gpg.encrypt(password, None, symmetric=True, passphrase=session_hash))
+        assert len(s), "For some reason GPG can't perform encryption, maybe check /root/.gnupg/gpg.conf or re-run with gpg = gnupg.GPG(verbose=True) ?"
+
         with self._open_sessionfile(session_id, 'w') as f:
-            f.write(str(gpg.encrypt(password, None, symmetric=True,
-                                    passphrase=session_hash)))
+            f.write(s)
 
     def _retrieve_session(self, session_id, session_hash):
         """Retrieve a session and return its associated password"""


### PR DESCRIPTION
So, today somebody encountered this stupid issue where he could not login anymore to the webadmin.

Turns out that for some reasons moulinette uses gpg to encrypt some values in cache. The issue lies in the fact that if there's an error in `/root/.gnupg/gpg.conf` (such as a bad option), `gpg.encrypt()` will simply return an empty string...

With verbosity on (`gnupg.GPG(verbose=True)`), we were able to see : `gpg: /root/.gnupg/gpg.conf:2: invalid`. The user told me that he was using duply for backups which also relies on gpg, and that might be related.

Anyway, I propose to add an assertion to check this to be able to pinpoint the issue more easily when this happens...