### PR TITLE
[enh] Display date as system timezone

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,8 @@ Depends: ${misc:Depends}, ${python:Depends},
     python-gnupg,
     python-gevent-websocket,
     python-argcomplete,
-    python-psutil
+    python-psutil,
+    python-tz
 Replaces: yunohost-cli
 Breaks: yunohost-cli
 Description: prototype interfaces with ease in Python

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -103,6 +103,8 @@ def pretty_date(_date):
     Argument:
         - date -- The date or datetime to display
     """
+    if _date.tzinfo is None:
+        _date = _date.replace(tzinfo=pytz.utc)
     if time.daylight:
         offsetHour = time.altzone / 3600
     else:

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -103,13 +103,19 @@ def pretty_date(_date):
     Argument:
         - date -- The date or datetime to display
     """
+    # Deduce system timezone
+    nowutc = datetime.now(tz=pytz.utc)
+    nowtz = datetime.now()
+    nowtz = nowtz.replace(tzinfo=pytz.utc)
+    offsetHour = nowutc - nowtz
+    offsetHour = int(round(offsetHour.total_seconds() / 3600))
+    localtz = 'Etc/GMT%+d' % offsetHour
+
+    # Transform naive date into UTC date
     if _date.tzinfo is None:
         _date = _date.replace(tzinfo=pytz.utc)
-    if time.daylight:
-        offsetHour = time.altzone / 3600
-    else:
-        offsetHour = time.timezone / 3600
-    localtz = 'Etc/GMT%+d' % offsetHour
+
+    # Convert UTC date into system locale date
     _date = _date.astimezone(pytz.timezone(localtz))
     if isinstance(_date, datetime):
         return _date.strftime("%Y-%m-%d %H:%M:%S")

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -8,6 +8,9 @@ import locale
 import logging
 from argparse import SUPPRESS
 from collections import OrderedDict
+import time
+import pytz
+from datetime import date, datetime
 
 import argcomplete
 
@@ -94,6 +97,24 @@ def plain_print_dict(d, depth=0):
         print(d)
 
 
+def pretty_date(_date):
+    """Display a date in the current time zone without ms and tzinfo
+
+    Argument:
+        - date -- The date or datetime to display
+    """
+    if time.daylight:
+        offsetHour = time.altzone / 3600
+    else:
+        offsetHour = time.timezone / 3600
+    localtz = 'Etc/GMT%+d' % offsetHour
+    _date = _date.astimezone(pytz.timezone(localtz))
+    if isinstance(_date, datetime):
+        return _date.strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        return _date.strftime("%Y-%m-%d")
+
+
 def pretty_print_dict(d, depth=0):
     """Print in a pretty way a dictionary recursively
 
@@ -127,10 +148,14 @@ def pretty_print_dict(d, depth=0):
                 else:
                     if isinstance(value, unicode):
                         value = value.encode('utf-8')
+                    elif isinstance(v, date):
+                        v = pretty_date(v)
                     print("{:s}- {}".format("  " * (depth + 1), value))
         else:
             if isinstance(v, unicode):
                 v = v.encode('utf-8')
+            elif isinstance(v, date):
+                v = pretty_date(v)
             print("{:s}{}: {}".format("  " * depth, k, v))
 
 

--- a/moulinette/utils/serialize.py
+++ b/moulinette/utils/serialize.py
@@ -1,6 +1,7 @@
 import logging
 from json.encoder import JSONEncoder
 import datetime
+import pytz
 
 logger = logging.getLogger('moulinette.utils.serialize')
 
@@ -26,7 +27,9 @@ class JSONExtendedEncoder(JSONEncoder):
             return list(o)
 
         # Display the date in its iso format ISO-8601 Internet Profile (RFC 3339)
-        if isinstance(o, datetime.datetime) or isinstance(o, datetime.date):
+        if isinstance(o, datetime.date):
+            if o.tzinfo is None:
+                o = o.replace(tzinfo=pytz.utc)
             return o.isoformat()
 
         # Return the repr for object that json can't encode


### PR DESCRIPTION
## The problem
Dates are not well displayed. Currently it's just a str(date) and in some case yunohost give a timestamp... We need to harmonize that, and manage timezone.

## Solution

Display dates using system timezone if we use cli.

Note: With the api, the json encoder already use iso format on the date object, so if the date is not "naive" date the representation generated by the api contains timezone info.
https://github.com/YunoHost/moulinette/blob/stretch-unstable/moulinette/utils/serialize.py#L30

## Status
Ready
This PR is linked to 
https://github.com/YunoHost/yunohost/pull/552