### PR TITLE
Fix LDAP authenticator when slapd was restarted

### DIFF
--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -76,7 +76,7 @@ class Authenticator(BaseAuthenticator):
 
     def authenticate(self, password):
         try:
-            con = ldap.initialize(self.uri)
+            con = ldap.ldapobject.ReconnectLDAPObject(self.uri, retry_max=5, retry_delay=0.1)
             if self.userdn:
                 con.simple_bind_s(self.userdn, password)
             else:


### PR DESCRIPTION
# Problem

When we restart slapd the authenticator object is broken. The result of that is that we need to make some hack like [that](https://github.com/YunoHost/yunohost/blob/stretch-unstable/src/yunohost/backup.py#L897-L899).

```
            # Quickfix: the old app_ssowatconf(auth) instruction failed due to
            # ldap restore hooks
            os.system('sudo yunohost app ssowatconf')
```

This issue also impact all test which are made after the backup test.

# Solution

Use an authenticator which are able to make a new connection if the connection is lost.