### PR TITLE
Create possiblity to add an preaction

### DIFF
--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -234,6 +234,12 @@ class BaseActionsMapParser(object):
         """
         self._o._conf[action] = self._validate_conf(configuration)
 
+    def set_preactions(self, configuration):
+        self._o._conf['preaction'] = configuration
+
+    def get_preactions(self):
+        return self._o._conf['preaction'] if 'preaction' in self._o._conf else []
+
     def _validate_conf(self, configuration, is_global=False):
         """Validate configuration for the parser
 


### PR DESCRIPTION
# Problem

I need to be able to do some action before to call the main action in the moulinette.

It's used by the PR : https://github.com/YunoHost/yunohost/pull/599

# Solution

Add a generic concept of action which can be called before the main action.

The actionmap is used to define what will be do. By example : 
```
    preaction:
        yunohost.preactions.checkmigrations:
            - main
```
Mean that the module function `main` from the module `yunohost.preactions.checkmigrations` will be executed.

The function main have two arguments:
- The  first argument is the function name of the Yunohost operation which will be done.
- The second will a dictionnary of the argument passed to the Yunohost operation.