### PR TITLE
Autopep8

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -25,6 +25,7 @@ logger = logging.getLogger('moulinette.actionsmap')
 # Extra parameters definition
 
 class _ExtraParameter(object):
+
     """
     Argument parser for an extra parameter.
 
@@ -104,6 +105,7 @@ class CommentParameter(_ExtraParameter):
 
 
 class AskParameter(_ExtraParameter):
+
     """
     Ask for the argument value if possible and needed.
 
@@ -138,6 +140,7 @@ class AskParameter(_ExtraParameter):
 
 
 class PasswordParameter(AskParameter):
+
     """
     Ask for the password argument value if possible and needed.
 
@@ -159,6 +162,7 @@ class PasswordParameter(AskParameter):
 
 
 class PatternParameter(_ExtraParameter):
+
     """
     Check if the argument value match a pattern.
 
@@ -204,6 +208,7 @@ class PatternParameter(_ExtraParameter):
 
 
 class RequiredParameter(_ExtraParameter):
+
     """
     Check if a required argument is defined or not.
 
@@ -240,6 +245,7 @@ extraparameters_list = [CommentParameter, AskParameter, PasswordParameter,
 
 
 class ExtraArgumentParser(object):
+
     """
     Argument validator and parser for the extra parameters.
 
@@ -357,6 +363,7 @@ def ordered_yaml_load(stream):
 
 
 class ActionsMap(object):
+
     """Validate and process actions defined into an actions map
 
     The actions map defines the features - and their usage - of an

--- a/moulinette/authenticators/__init__.py
+++ b/moulinette/authenticators/__init__.py
@@ -12,6 +12,7 @@ logger = logging.getLogger('moulinette.authenticator')
 # Base Class -----------------------------------------------------------
 
 class BaseAuthenticator(object):
+
     """Authenticator base representation
 
     Each authenticators must implement an Authenticator class derived

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -18,6 +18,7 @@ logger = logging.getLogger('moulinette.authenticator.ldap')
 # LDAP Class Implementation --------------------------------------------
 
 class Authenticator(BaseAuthenticator):
+
     """LDAP Authenticator
 
     Initialize a LDAP connexion for the given arguments. It attempts to

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -19,6 +19,7 @@ logger = logging.getLogger('moulinette.core')
 # Internationalization -------------------------------------------------
 
 class Translator(object):
+
     """Internationalization class
 
     Provide an internationalization mechanism based on JSON files to
@@ -137,6 +138,7 @@ class Translator(object):
 
 
 class Moulinette18n(object):
+
     """Internationalization service for the moulinette
 
     Manage internationalization and access to the proper keys translation
@@ -214,6 +216,7 @@ class Moulinette18n(object):
 
 
 class MoulinetteSignals(object):
+
     """Signals connector for the moulinette
 
     Allow to easily connect signals from the moulinette to handlers. A
@@ -365,7 +368,7 @@ def init_interface(name, kwargs={}, actionsmap={}):
     return interface(amap, **kwargs)
 
 
-def init_authenticator((vendor, name), kwargs={}):
+def init_authenticator(vendor_and_name, kwargs={}):
     """Return a new authenticator instance
 
     Retrieve the given authenticator vendor and return a new instance of
@@ -377,6 +380,7 @@ def init_authenticator((vendor, name), kwargs={}):
         - kwargs -- A dict of arguments for the authenticator profile
 
     """
+    (vendor, name) = vendor_and_name
     try:
         mod = import_module('moulinette.authenticators.%s' % vendor)
     except ImportError:
@@ -410,8 +414,10 @@ def clean_session(session_id, profiles=[]):
 
 # Moulinette core classes ----------------------------------------------
 
-class MoulinetteError(StandardError):
+class MoulinetteError(Exception):
+
     """Moulinette base exception"""
+
     def __init__(self, key, __raw_msg__=False, *args, **kwargs):
         if __raw_msg__:
             msg = key
@@ -422,6 +428,7 @@ class MoulinetteError(StandardError):
 
 
 class MoulinetteLock(object):
+
     """Locker for a moulinette instance
 
     It provides a lock mechanism for a given moulinette instance. It can

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -19,6 +19,7 @@ CALLBACKS_PROP = '_callbacks'
 # Base Class -----------------------------------------------------------
 
 class BaseActionsMapParser(object):
+
     """Actions map's base Parser
 
     Each interfaces must implement an ActionsMapParser class derived
@@ -352,6 +353,7 @@ class BaseActionsMapParser(object):
 
 
 class BaseInterface(object):
+
     """Moulinette's base Interface
 
     Each interfaces must implement an Interface class derived from this
@@ -424,7 +426,7 @@ class _CallbackAction(argparse.Action):
             value = self.callback(namespace, values, **self.callback_kwargs)
         except:
             logger.exception("cannot get value from callback method "
-                "'{0}'".format(self.callback_method))
+                             "'{0}'".format(self.callback_method))
             raise MoulinetteError('error_see_log')
         else:
             if value:
@@ -435,6 +437,7 @@ class _CallbackAction(argparse.Action):
 
 
 class _ExtendedSubParsersAction(argparse._SubParsersAction):
+
     """Subparsers with extended properties for argparse
 
     It provides the following additional properties at initialization,

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -57,11 +57,13 @@ def filter_csrf(callback):
 
 
 class LogQueues(dict):
+
     """Map of session id to queue."""
     pass
 
 
 class APIQueueHandler(logging.Handler):
+
     """
     A handler class which store logging records into a queue, to be used
     and retrieved from the API.
@@ -87,6 +89,7 @@ class APIQueueHandler(logging.Handler):
 
 
 class _HTTPArgumentParser(object):
+
     """Argument parser for HTTP requests
 
     Object for parsing HTTP requests into Python objects. It is based
@@ -193,6 +196,7 @@ class _HTTPArgumentParser(object):
 
 
 class _ActionsMapPlugin(object):
+
     """Actions map Bottle Plugin
 
     Process relevant action for the request using the actions map and
@@ -538,11 +542,11 @@ def error_to_response(error):
         return HTTPUnauthorizedResponse(error.strerror)
     # Client-side error
     elif error.errno in [errno.ENOENT, errno.ESRCH, errno.ENXIO, errno.EEXIST,
-            errno.ENODEV, errno.EINVAL, errno.ENOPKG, errno.EDESTADDRREQ]:
+                         errno.ENODEV, errno.EINVAL, errno.ENOPKG, errno.EDESTADDRREQ]:
         return HTTPBadRequestResponse(error.strerror)
     # Server-side error
     elif error.errno in [errno.EIO, errno.EBUSY, errno.ENODATA, errno.EINTR,
-            errno.ENETUNREACH]:
+                         errno.ENETUNREACH]:
         return HTTPErrorResponse(error.strerror)
     else:
         logger.debug('unknown relevant response for error [%s] %s',
@@ -571,6 +575,7 @@ def format_for_response(content):
 # API Classes Implementation -------------------------------------------
 
 class ActionsMapParser(BaseActionsMapParser):
+
     """Actions map's Parser for the API
 
     Provide actions map parsing methods for a CLI usage. The parser for
@@ -707,6 +712,7 @@ class ActionsMapParser(BaseActionsMapParser):
 
 
 class Interface(BaseInterface):
+
     """Application Programming Interface for the moulinette
 
     Initialize a HTTP server which serves the API connected to a given

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -177,6 +177,7 @@ def get_locale():
 # CLI Classes Implementation -------------------------------------------
 
 class TTYHandler(logging.StreamHandler):
+
     """TTY log handler
 
     A handler class which prints logging records for a tty. The record is
@@ -242,6 +243,7 @@ class TTYHandler(logging.StreamHandler):
 
 
 class ActionsMapParser(BaseActionsMapParser):
+
     """Actions map's Parser for the CLI
 
     Provide actions map parsing methods for a CLI usage. The parser for
@@ -369,6 +371,7 @@ class ActionsMapParser(BaseActionsMapParser):
 
 
 class Interface(BaseInterface):
+
     """Command-line Interface for the moulinette
 
     Initialize an interface connected to the standard input/output

--- a/moulinette/utils/filesystem.py
+++ b/moulinette/utils/filesystem.py
@@ -144,7 +144,7 @@ def write_to_json(file_path, data):
         raise MoulinetteError('_error_writing_file', file=file_path, error=str(e))
 
 
-def mkdir(path, mode=0777, parents=False, uid=None, gid=None, force=False):
+def mkdir(path, mode=0o777, parents=False, uid=None, gid=None, force=False):
     """Create a directory with optional features
 
     Create a directory and optionaly set its permissions to mode and its

--- a/moulinette/utils/log.py
+++ b/moulinette/utils/log.py
@@ -70,6 +70,7 @@ def getHandlersByClass(classinfo, limit=0):
 
 
 class MoulinetteLogger(Logger):
+
     """Custom logger class
 
     Extend base Logger class to provide the SUCCESS custom log level with
@@ -153,6 +154,7 @@ def getActionLogger(name=None, logger=None, action_id=None):
 
 
 class ActionFilter(object):
+
     """Extend log record for an optionnal action
 
     Filter a given record and look for an `action_id` key. If it is not found

--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -60,7 +60,7 @@ def call_async_output(args, callback, **kwargs):
     if "stdinfo" in kwargs and kwargs["stdinfo"] is not None:
         assert len(callback) == 3
         stdinfo = kwargs.pop("stdinfo")
-        os.mkfifo(stdinfo, 0600)
+        os.mkfifo(stdinfo, 0o600)
         # Open stdinfo for reading (in a nonblocking way, i.e. even
         # if command does not write in the stdinfo pipe...)
         stdinfo_f = os.open(stdinfo, os.O_RDONLY | os.O_NONBLOCK)

--- a/moulinette/utils/serialize.py
+++ b/moulinette/utils/serialize.py
@@ -9,6 +9,7 @@ logger = logging.getLogger('moulinette.utils.serialize')
 # JSON utilities -------------------------------------------------------
 
 class JSONExtendedEncoder(JSONEncoder):
+
     """Extended JSON encoder
 
     Extend default JSON encoder to recognize more types and classes. It

--- a/moulinette/utils/stream.py
+++ b/moulinette/utils/stream.py
@@ -8,6 +8,7 @@ from multiprocessing.queues import SimpleQueue
 # Read from a stream ---------------------------------------------------
 
 class AsynchronousFileReader(Process):
+
     """
     Helper class to implement asynchronous reading of a file
     in a separate thread. Pushes read lines on a queue to
@@ -74,6 +75,7 @@ class AsynchronousFileReader(Process):
 
 
 class Consummer(object):
+
     def __init__(self, queue, callback):
         self.queue = queue
         self.callback = callback


### PR DESCRIPTION
## The problem

Pep8 complains about quite a lot of things

## Solution

Ran `autopep8 -i --ignore=E501 -a -a -a -a -a *.py */*.py`
(Made a few manual tweaks because a few changes were made which werent so logical o.O)

Turns out `autopep8` also makes some adjustments for Python3 compatibility which is nice :+1: 

N.B. : this PR is on top of https://github.com/YunoHost/moulinette/pull/180
N.B. : this changes MoulinetteError inheritance from StandardError to Exception

## PR Status

Not tested but most of those are only whitespace changes

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 