### PR TITLE
Ugly hack to disconnect ldap right after action processing is done

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -526,6 +526,18 @@ class ActionsMap(object):
                     logger.debug('action [%s] executed in %.3fs',
                                  log_id, stop - start)
 
+                    # For some reason we need to do this now before the
+                    # garbage collector kicks in ...
+                    # ... because sometimes the ldap library is already half
+                    # gone when trying to properly close the ldap object
+                    # which leads to  :
+                    # TypeError: "'NoneType' object is not callable" in <bound method Authenticator.__del__ of <moulinette.authenticators.ldap.Authenticator object at 0xabcdef123456>> ignored
+                    # (here the NoneType stuff refers to RequestControlTuples in ldapobject.py ...)
+                    # I got this when running `yunohost user list` (but not when running `yunohost domain list` for some reason)
+                    from moulinette.authenticators.ldap import Authenticator
+                    for i in Authenticator.instances:
+                        i().freecon()
+
     @staticmethod
     def get_namespaces():
         """


### PR DESCRIPTION
So c.f. https://github.com/YunoHost/yunohost/pull/721#issuecomment-491117107 which is a stupidly weird issue only occuring when running `yunohost user list` (e.g. `yunohost domain list` works fine ...)

I even noticed that adding some unrelated import (e.g. `import apt` ... whatever) inside `user_list()` makes the issue disappear. Which makes me think it's some kind of weird bug inside Python's garbage collection.

I tracked it down to the fact that, inside the ldap library code, during the call to `unbind_s`, the object `RequestControlTuples` is `None` for some reason (already deleted by Python ?) : 

https://github.com/python-ldap/python-ldap/blob/master/Lib/ldap/ldapobject.py#L29
https://github.com/python-ldap/python-ldap/blob/master/Lib/ldap/ldapobject.py#L883

Anyway ... this is an ugly fix that just closes the connection properly before the actual end of the program, so that we can be more sure that python didn't start already to destroy random stuff ...

For this I save all the instances of LDAP `Authenticator` in a static list, and I call the disconnect thing at the end of `process`
