### PR TITLE
Basic developer documentation and dependency setuptools integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ operation on an interface for example (see
 ### Authenticators
 ...
 
+Development Install
+-------------------
+
+```bash
+$ pip install -e .
+```
+
+Test
+----
+
+```bash
+$ pytest
+```
 
 Requirements
 ------------

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -4,7 +4,6 @@ import os
 import time
 import json
 import logging
-import psutil
 
 from importlib import import_module
 
@@ -525,6 +524,10 @@ class MoulinetteLock(object):
         return lock_pids
 
     def _is_son_of(self, lock_pids):
+        # in order to avoid a setuptools installation issue which fails at
+        # installation time, we only import psutil when appropriate and not
+        # globally at the module level
+        import psutil
 
         if lock_pids == []:
             return False

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,19 @@ setup(name='Moulinette',
           'moulinette.utils',
       ],
       data_files=[(LOCALES_DIR, locale_files)],
-      tests_require=["pytest", "webtest"],
+      install_requires=[
+        'PyYAML >= 5.1',
+        'bottle >= 0.10',
+        'gnupg >= 0.3',
+        'python-ldap >= 2.4',
+      ],
+      tests_require=[
+        'pytest',
+        'webtest'
+        'gevent',
+        'gevent-websocket',
+        'pytz',
+        'requests',
+        'requests_mock',
+      ],
       )


### PR DESCRIPTION
I was taking a pass through "easy-pick" issues and decided to start off on something small over at https://github.com/YunoHost/issues/issues/5. I know https://github.com/YunoHost/moulinette/pull/172 is happening but is somehow stalled since a long time.

This change helps to install local development install of this package for now.

Btw, when I run the tests, they all fail. Is there some further setup I need to get this working? How do I test this package? Do I need to run this all in the context of a development yunohost environment?