### PR TITLE
Warn the user about long locks for a way better UX

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -53,5 +53,6 @@
     "download_bad_status_code": "{url:s} returned status code {code:s}",
     "command_unknown": "Command '{command:s}' unknown ?",
     "warn_the_user_about_waiting_lock": "Another YunoHost command is running right now, we are waiting for it to finish before running this one",
-    "warn_the_user_about_waiting_lock_again": "Still waiting..."
+    "warn_the_user_about_waiting_lock_again": "Still waiting...",
+    "warn_the_user_that_lock_is_acquired": "the other command just complet, now starting this command"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -51,5 +51,7 @@
     "download_timeout": "{url:s} took too long to answer, gave up.",
     "download_unknown_error": "Error when downloading data from {url:s}: {error:s}",
     "download_bad_status_code": "{url:s} returned status code {code:s}",
-    "command_unknown": "Command '{command:s}' unknown?"
+    "command_unknown": "Command '{command:s}' unknown ?",
+    "warn_the_user_about_waiting_lock": "another YunoHost command is running right now, we are waiting for it to finish before running this one",
+    "warn_the_user_about_waiting_lock_again": "still waiting..."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -52,6 +52,6 @@
     "download_unknown_error": "Error when downloading data from {url:s}: {error:s}",
     "download_bad_status_code": "{url:s} returned status code {code:s}",
     "command_unknown": "Command '{command:s}' unknown ?",
-    "warn_the_user_about_waiting_lock": "another YunoHost command is running right now, we are waiting for it to finish before running this one",
+    "warn_the_user_about_waiting_lock": "Another YunoHost command is running right now, we are waiting for it to finish before running this one",
     "warn_the_user_about_waiting_lock_again": "Still waiting..."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -53,5 +53,5 @@
     "download_bad_status_code": "{url:s} returned status code {code:s}",
     "command_unknown": "Command '{command:s}' unknown ?",
     "warn_the_user_about_waiting_lock": "another YunoHost command is running right now, we are waiting for it to finish before running this one",
-    "warn_the_user_about_waiting_lock_again": "still waiting..."
+    "warn_the_user_about_waiting_lock_again": "Still waiting..."
 }

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -461,6 +461,8 @@ class MoulinetteLock(object):
         """
         start_time = time.time()
 
+        logger.debug('acquiring lock...')
+
         while True:
 
             lock_pids = self._lock_PIDs()

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -504,6 +504,10 @@ class MoulinetteLock(object):
             # Wait before checking again
             time.sleep(self.interval)
 
+        # we have warned the user that we were waiting, for better UX also them
+        # that we have stop waiting and that the command is processing now
+        if warning_treshold != 15:
+            logger.warning(moulinette.m18n.g('warn_the_user_that_lock_is_acquired'))
         logger.debug('lock has been acquired')
         self._locked = True
 

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -461,6 +461,13 @@ class MoulinetteLock(object):
         """
         start_time = time.time()
 
+        # for UX reason, we are going to warn the user that we are waiting for
+        # another yunohost command to end, otherwise the user is very confused
+        # and don't understand that and think yunohost is broken
+        # we are going to warn the user after 15 seconds of waiting time then
+        # after 15*4 seconds, then 15*4*4 seconds...
+        warning_treshold = 15
+
         logger.debug('acquiring lock...')
 
         while True:
@@ -485,6 +492,15 @@ class MoulinetteLock(object):
 
             if self.timeout is not None and (time.time() - start_time) > self.timeout:
                 raise MoulinetteError('instance_already_running')
+
+            # warn the user if it's been too much time since they are waiting
+            if (time.time() - start_time) > warning_treshold:
+                if warning_treshold == 15:
+                    logger.warning(moulinette.m18n.g('warn_the_user_about_waiting_lock'))
+                else:
+                    logger.warning(moulinette.m18n.g('warn_the_user_about_waiting_lock_again'))
+                warning_treshold *= 4
+
             # Wait before checking again
             time.sleep(self.interval)
 


### PR DESCRIPTION
Today (and like in several other cases) I end up in front of a user convinced that their YunoHost was totally broken because they though that nothing worked anymore. I've suspected the lock directly but it was hard to debug because even `--debug` didn't informed that YunoHost was waiting for the lock.

So this PR add 2 mechanism to fix this:

* add a simple `logger.debug` line to tell that we are entering the lock mechanism
* add a gradual `logger.warning` mechanism to tell the user that we are waiting and still waiting for the other command to finish

My formulation for the second error message might not be very clear so if you have a better suggestion try to improve it please.

I'm also expecting those message to bring users try to understand what is happening and how to debug that, one better solution for that would be to have a specific documentation page for this situation and link to it, but we don't have one :/ So in the meantime this already seems like a needed improvement.

Another way way better improvement would be for every command that take to lock to say what it is doing (like "listing domain") and that's really an improvement I'm considering doing and we could use the "description" already available in the `actionmaps.yaml` or add this information in it. But that's much more work that I can do right now :/

On "what would be the so much better solution that we won't have the time to do, lol": I really think that YunoHost should swtich from a lock oriented approach to a "jobs list" approach where you can see at anytime all the current process that are waiting and running and killing or reordering all of the them. But that's really way much more work.