### PR TITLE
Invoke Pytest fixture options correctly

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,8 +91,8 @@ def patch_logging(moulinette):
     )
 
 
-@pytest.fixture
-def moulinette(scope='session', autouse=True):
+@pytest.fixture(scope='session', autouse=True)
+def moulinette():
     import moulinette
 
     patch_init(moulinette)


### PR DESCRIPTION
For documentation, see https://docs.pytest.org/en/latest/fixture.html#scope-sharing-a-fixture-instance-across-tests-in-a-class-module-or-session. I missed this on the last PR #203.