### PR TITLE
[mod] add gnupg1 as explicit dependency to avoid its removal

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Homepage: https://github.com/YunoHost/moulinette
 Package: moulinette
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},
+    gnupg1,
     python-ldap,
     python-yaml,
     python-bottle (>= 0.12),


### PR DESCRIPTION
According to https://packages.debian.org/stretch/python-gnupg it's the "gnupg1" package that we need (and not "gnupg" itself) for some weird compatibility reasons.

Link to https://github.com/YunoHost/issues/issues/1326 in which apparently installing "gnupg2" pulled "gnupg" (but not gnupg1?) https://packages.debian.org/stretch/gnupg2 I'm not sure, it looks like a mess :/

Last time I've checked python-gnupg was using "gpg1" binary but the source code is annoying to read. Here is which pkg provide which binary:

```
root@ynh:/etc/yunohost/apps/ynhexample__2# apt-file search "bin/gpg"
gnupg: /usr/bin/gpg
gnupg: /usr/bin/gpg-zip
gnupg: /usr/bin/gpgconf
gnupg: /usr/bin/gpgparsemail
gnupg: /usr/bin/gpgsplit
gnupg-agent: /usr/bin/gpg-agent
gnupg-agent: /usr/bin/gpg-connect-agent
gnupg1: /usr/bin/gpg1
gnupg2: /usr/bin/gpg2

```