### PR TITLE
Add lint job to Tox and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: python
-install: pip install tox pep8
-python:
-    - 2.7
-script: 
-  - pep8 moulinette
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 2.7
+      env: TOXENV=lint
+
+install:
+  - pip install tox
+
+script:
   - tox

--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ Requirements
 * python-gnupg (>= 0.3)
 * python-ldap (>= 2.4)
 * PyYAML
+
+Testing
+-------
+
+```
+$ pip install tox
+$ tox
+```

--- a/moulinette/interfaces/__init__.py
+++ b/moulinette/interfaces/__init__.py
@@ -645,7 +645,7 @@ class PositionalsFirstHelpFormatter(argparse.HelpFormatter):
 
     def _format_usage(self, usage, actions, groups, prefix):
         if prefix is None:
-                # TWEAK : not using gettext here...
+            # TWEAK : not using gettext here...
             prefix = 'usage: '
 
         # if usage is specified, use that

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -11,7 +11,7 @@ from gevent.queue import Queue
 from geventwebsocket import WebSocketError
 
 from bottle import run, request, response, Bottle, HTTPResponse
-from bottle import get, post, install, abort, delete, put
+from bottle import abort
 
 from moulinette import msignals, m18n, DATA_DIR
 from moulinette.core import MoulinetteError, clean_session

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -7,7 +7,6 @@ import locale
 import logging
 from argparse import SUPPRESS
 from collections import OrderedDict
-import time
 import pytz
 from datetime import date, datetime
 

--- a/moulinette/utils/log.py
+++ b/moulinette/utils/log.py
@@ -3,7 +3,7 @@ import logging
 
 # import all constants because other modules try to import them from this
 # module because SUCCESS is defined in this module
-from logging import (addLevelName, setLoggerClass, Logger, getLogger, NOTSET,
+from logging import (addLevelName, setLoggerClass, Logger, getLogger, NOTSET,  # noqa
                      DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pep8]
-ignore = E501,E128,E731
+[flake8]
+ignore = E501,E128,E731,E722

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py27
+envlist = 
+  py27
+  lint
 skipdist = True
 isolated_build = True
 
@@ -15,3 +17,9 @@ deps =
   requests-mock >= 1.6.0, < 2.0
 commands =
     pytest {posargs}
+
+[testenv:lint]
+commands = flake8 moulinette test
+deps = flake8
+skip_install = True
+usedevelop = False


### PR DESCRIPTION
So, let's use Tox to run pycodestyle (new name for pep8) and run it in a parallel job.

Why? Well, I want to also start to introduce new jobs to Tox / Travis.

In the end, the developer experience will always be "just run pip install tox && tox"