### PR TITLE
[fix] Return nothing if argument is already set.

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -89,6 +89,9 @@ class CommentParameter(_ExtraParameter):
     skipped_iface = ['api']
 
     def __call__(self, message, arg_name, arg_value):
+        if arg_value:
+            return
+        
         return msignals.display(m18n.n(message))
 
     @classmethod

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -91,7 +91,6 @@ class CommentParameter(_ExtraParameter):
     def __call__(self, message, arg_name, arg_value):
         if arg_value:
             return
-        
         return msignals.display(m18n.n(message))
 
     @classmethod


### PR DESCRIPTION
## Problem
Even if  the password is in argument of user create (I think it's the same for other commands).

## Solution
Return nothing if arg_value is already set

## How to test
ynh-dev : 
(./ynh-dev start (start container))

To test if behaviors has change **when we don't provide password arg** : 
sudo yunohost user create frju370 --firstname hello --debug

To test how it behaves when **password arg is provided** : 
sudo yunohost user create frju370 --firstname hello -p 00022522104mplo--debug

## Status
**Tested** (need review)

## Misc

fixes https://github.com/YunoHost/issues/issues/1477

