### PR TITLE
Don't update LDAP if there are nothing to do

### DIFF
--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -232,6 +232,9 @@ class Authenticator(BaseAuthenticator):
         actual_entry = self.search(base=dn, attrs=None)
         ldif = modlist.modifyModlist(actual_entry[0], attr_dict, ignore_oldexistent=1)
 
+        if ldif == []:
+            return True
+
         try:
             if new_rdn:
                 self.con.rename_s(dn, new_rdn)

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -233,6 +233,7 @@ class Authenticator(BaseAuthenticator):
         ldif = modlist.modifyModlist(actual_entry[0], attr_dict, ignore_oldexistent=1)
 
         if ldif == []:
+            logger.warning("Nothing to update in LDAP")
             return True
 
         try:


### PR DESCRIPTION
# Problem

If we try to update the LDAP database with no chang `slapd` crash, and it's a big problem.

# Solution

Check if there are a real change to do and if not do nothing.
