### PR TITLE
Fix tests and linter not already fixed by #227

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -419,6 +419,7 @@ class ActionsMap(object):
         moulinette_env = init_moulinette_env()
         DATA_DIR = moulinette_env["DATA_DIR"]
         CACHE_DIR = moulinette_env["CACHE_DIR"]
+        self.run_dir = moulinette_env["RUN_DIR"]
 
         if len(namespaces) == 0:
             namespaces = self.get_namespaces()
@@ -545,7 +546,7 @@ class ActionsMap(object):
             full_action_name = "%s.%s.%s" % (namespace, category, action)
 
         # Lock the moulinette for the namespace
-        with MoulinetteLock(namespace, timeout):
+        with MoulinetteLock(namespace, timeout, lock_dir=self.run_dir):
             start = time()
             try:
                 mod = __import__(

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -117,7 +117,7 @@ class Authenticator(BaseAuthenticator):
 
         # we aren't using sha-512 but something else that is weaker, proceed to upgrade
         if not hashed_password["userPassword"][0].startswith("{CRYPT}$6$"):
-            self.update("cn=admin", {"userPassword": _hash_user_password(password),})
+            self.update("cn=admin", {"userPassword": _hash_user_password(password), })
 
     # Additional LDAP methods
     # TODO: Review these methods

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -454,12 +454,12 @@ class MoulinetteLock(object):
 
     """
 
-    def __init__(self, namespace, timeout=None, interval=0.5):
+    def __init__(self, namespace, timeout=None, interval=0.5, lock_dir="/var/run"):
         self.namespace = namespace
         self.timeout = timeout
         self.interval = interval
 
-        self._lockfile = "/var/run/moulinette_%s.lock" % namespace
+        self._lockfile = "{}/moulinette_{}.lock".format(lock_dir, namespace)
         self._stale_checked = False
         self._locked = False
 

--- a/moulinette/globals.py
+++ b/moulinette/globals.py
@@ -11,4 +11,5 @@ def init_moulinette_env():
             "MOULINETTE_LOCALES_DIR", "/usr/share/moulinette/locale"
         ),
         "CACHE_DIR": environ.get("MOULINETTE_CACHE_DIR", "/var/cache/moulinette"),
+        "RUN_DIR": environ.get("MOULINETTE_RUN_DIR", "/var/run")
     }

--- a/moulinette/utils/log.py
+++ b/moulinette/utils/log.py
@@ -3,12 +3,12 @@ import logging
 
 # import all constants because other modules try to import them from this
 # module because SUCCESS is defined in this module
-from logging import (
+from logging import (  # noqa: F401
     addLevelName,
     setLoggerClass,
     Logger,
     getLogger,
-    NOTSET,  # noqa
+    NOTSET,
     DEBUG,
     INFO,
     WARNING,
@@ -35,7 +35,7 @@ DEFAULT_LOGGING = {
             "stream": "ext://sys.stdout",
         },
     },
-    "loggers": {"moulinette": {"level": "DEBUG", "handlers": ["console"],},},
+    "loggers": {"moulinette": {"level": "DEBUG", "handlers": ["console"], }, },
 }
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ testpaths = test/
 env =
   MOULINETTE_LOCALES_DIR = {PWD}/locales
   TESTS_RUN = True
+  MOULINETTE_RUN_DIR=.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,7 +53,7 @@ def patch_logging(moulinette):
                 "format": "%(asctime)-15s %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s"  # noqa
             },
         },
-        "filters": {"action": {"()": "moulinette.utils.log.ActionFilter",},},
+        "filters": {"action": {"()": "moulinette.utils.log.ActionFilter", }, },
         "handlers": {
             "api": {
                 "level": level,
@@ -66,14 +66,14 @@ def patch_logging(moulinette):
             },
         },
         "loggers": {
-            "moulinette": {"level": level, "handlers": [], "propagate": True,},
+            "moulinette": {"level": level, "handlers": [], "propagate": True, },
             "moulinette.interface": {
                 "level": level,
                 "handlers": handlers,
                 "propagate": False,
             },
         },
-        "root": {"level": level, "handlers": root_handlers,},
+        "root": {"level": level, "handlers": root_handlers, },
     }
 
 


### PR DESCRIPTION
Together with #227, this should make the build green.

The root cause of the last failing tests the fact moulinette is writing its lockfiles in `/var/run`. However, at least on Ubuntu, only root can do that. 

This PR fixes that by allowing to configure the runtime dir of moulinette. I chose to add an env variable for this purpose, as it seems more appropriate than in the yml file.

To make things complete, I also added a commit that fixes the linter.