### PR TITLE
The hell with 'pythonic try/except' ... Just use a goddamn if/else for that kind of stuff

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -327,11 +327,10 @@ class _ActionsMapPlugin(object):
             # Append other request params
             for k, v in request.params.dict.items():
                 v = _format(v)
-                try:
-                    curr_v = params[k]
-                except KeyError:
+                if k not in params.keys():
                     params[k] = v
                 else:
+                    curr_v = params[k]
                     # Append param value to the list
                     if not isinstance(curr_v, list):
                         curr_v = [curr_v]


### PR DESCRIPTION
This was my initial attempt to fix https://github.com/YunoHost/issues/issues/1549 (until I saw that it still displayed None .. c.f. the root cause discussed in https://github.com/YunoHost/yunohost/pull/952 )

Anyway, I don't understand why people do that kind of try except ... Let's just explicitly say that if the key is not in the dict, we want to do something, and something else otherwise ...