### PR TITLE
try/catch around request.get_cookie to catch stupid CookieError

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -362,13 +362,24 @@ class _ActionsMapPlugin(object):
 
         """
         # Retrieve session values
-        s_id = request.get_cookie("session.id") or random_ascii()
+        try:
+            s_id = request.get_cookie("session.id") or random_ascii()
+        except:
+            # Super rare case where there are super weird cookie / cache issue
+            # Previous line throws a CookieError that creates a 500 error ...
+            # So let's catch it and just use a fresh ID then...
+            s_id = random_ascii()
+            
         try:
             s_secret = self.secrets[s_id]
         except KeyError:
             s_tokens = {}
         else:
-            s_tokens = request.get_cookie("session.tokens", secret=s_secret) or {}
+            try:
+                s_tokens = request.get_cookie("session.tokens", secret=s_secret) or {}
+            except:
+                # Same as for session.id a few lines before
+                s_tokens = {}
         s_new_token = random_ascii()
 
         try:

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -369,7 +369,7 @@ class _ActionsMapPlugin(object):
             # Previous line throws a CookieError that creates a 500 error ...
             # So let's catch it and just use a fresh ID then...
             s_id = random_ascii()
-            
+
         try:
             s_secret = self.secrets[s_id]
         except KeyError:


### PR DESCRIPTION
A user had this stacktrace today for some reason ...

```
    File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/api.py", line 334, in login
      s_id = request.get_cookie('session.id') or random_ascii()
    [...]
    File "/usr/lib/python2.7/dist-packages/bottle.py", line 1051, in cookies
      cookies = SimpleCookie(self.environ.get('HTTP_COOKIE','')).values()
    [...]
    File "/usr/lib/python2.7/Cookie.py", line 589, in __set
      M.set(key, real_value, coded_value)
    File "/usr/lib/python2.7/Cookie.py", line 459, in set
      raise CookieError("Illegal key value: %s" % key)
  CookieError: Illegal key value: ys-api/mpegts/mux
```

Dunno where that weird cookie comes from, there are similar issues on the internets in various project ...

Anyway wrappign the line in a try/except should avoid this ...