### PR TITLE
Less spooky messages when session expired

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -31,6 +31,7 @@
     "success": "Success!",
     "unable_authenticate": "Unable to authenticate",
     "unable_retrieve_session": "Unable to retrieve the session because '{exception}'",
+    "session_expired": "The session expired. Please re-authenticate.",
     "unknown_group": "Unknown '{group}' group",
     "unknown_user": "Unknown '{user}' user",
     "values_mismatch": "Values don't match",

--- a/moulinette/authenticators/__init__.py
+++ b/moulinette/authenticators/__init__.py
@@ -174,7 +174,7 @@ class BaseAuthenticator(object):
 
     def _authenticate_session(self, session_id, session_token):
         """Checks session and token against the stored session token"""
-        if not self._session_exists(self, session_id):
+        if not self._session_exists(session_id):
             raise MoulinetteError("session_expired")
         try:
             # FIXME : shouldn't we also add a check that this session file

--- a/moulinette/authenticators/__init__.py
+++ b/moulinette/authenticators/__init__.py
@@ -5,7 +5,7 @@ import logging
 import hashlib
 import hmac
 
-from moulinette.cache import open_cachefile, get_cachedir
+from moulinette.cache import open_cachefile, get_cachedir, cachefile_exists
 from moulinette.core import MoulinetteError
 
 logger = logging.getLogger("moulinette.authenticator")
@@ -159,6 +159,10 @@ class BaseAuthenticator(object):
             "%s.asc" % session_id, mode, subdir="session/%s" % self.name
         )
 
+    def _session_exists(self, session_id):
+        """Check a session exists"""
+        return cachefile_exists("%s.asc" % session_id, subdir="session/%s" % self.name)
+
     def _store_session(self, session_id, session_token):
         """Store a session to be able to use it later to reauthenticate"""
 
@@ -170,6 +174,8 @@ class BaseAuthenticator(object):
 
     def _authenticate_session(self, session_id, session_token):
         """Checks session and token against the stored session token"""
+        if not self._session_exists(self, session_id):
+            raise MoulinetteError("session_expired")
         try:
             # FIXME : shouldn't we also add a check that this session file
             # is not too old ? e.g. not older than 24 hours ? idk...

--- a/moulinette/cache.py
+++ b/moulinette/cache.py
@@ -42,3 +42,10 @@ def open_cachefile(filename, mode="r", subdir=""):
     cache_dir = get_cachedir(subdir, make_dir=True if mode[0] == "w" else False)
     file_path = os.path.join(cache_dir, filename)
     return open(file_path, mode)
+
+
+def cachefile_exists(filename, subdir=""):
+
+    cache_dir = get_cachedir(subdir, make_dir=False)
+    file_path = os.path.join(cache_dir, filename)
+    return os.path.exists(file_path)


### PR DESCRIPTION
c.f. https://github.com/YunoHost/issues/issues/1554

Not sure exactly why / when / how but I sometimes see 

```
 Unable to retrieve the session because '[Errno 2] No such file or directory: '/var/cache/moulinette/session/[someid].asc
```

in webadmin during self-upgrades

This PR makes the code a bit smarter and checks the session file exists... Otherwise it most probably means the session expired.