### PR TITLE
[fix] try to autorestart ldap when the server is down

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -54,5 +54,6 @@
     "command_unknown": "Command '{command:s}' unknown ?",
     "warn_the_user_about_waiting_lock": "Another YunoHost command is running right now, we are waiting for it to finish before running this one",
     "warn_the_user_about_waiting_lock_again": "Still waiting...",
-    "warn_the_user_that_lock_is_acquired": "the other command just completed, now starting this command"
+    "warn_the_user_that_lock_is_acquired": "the other command just completed, now starting this command",
+    "ldap_server_is_down_restart_it": "the ldap service is down, attempt to restart it..."
 }

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -92,7 +92,7 @@ class Authenticator(BaseAuthenticator):
             raise MoulinetteError("invalid_password")
         except ldap.SERVER_DOWN:
             # ldap is down, attempt to restart it before really failing
-            logger.warning(m18n.g("ldap_server_down"))
+            logger.warning(m18n.g("ldap_server_is_down_restart_it"))
             os.system("systemctl restart slapd")
             time.sleep(10)  # waits 10 secondes so we are sure that slapd has restarted
 

--- a/moulinette/authenticators/ldap.py
+++ b/moulinette/authenticators/ldap.py
@@ -2,15 +2,18 @@
 
 # TODO: Use Python3 to remove this fix!
 from __future__ import absolute_import
+import os
 import logging
 import random
 import string
 import crypt
 import ldap
 import ldap.sasl
+import time
 import ldap.modlist as modlist
 
-from moulinette.core import MoulinetteError
+from moulinette import m18n
+from moulinette.core import MoulinetteError, MoulinetteLdapIsDownError
 from moulinette.authenticators import BaseAuthenticator
 
 logger = logging.getLogger("moulinette.authenticator.ldap")
@@ -69,7 +72,7 @@ class Authenticator(BaseAuthenticator):
     # Implement virtual methods
 
     def authenticate(self, password=None):
-        try:
+        def _reconnect():
             con = ldap.ldapobject.ReconnectLDAPObject(
                 self._get_uri(), retry_max=10, retry_delay=0.5
             )
@@ -80,11 +83,23 @@ class Authenticator(BaseAuthenticator):
                     con.simple_bind_s(self.userdn, password)
             else:
                 con.simple_bind_s()
+
+            return con
+
+        try:
+            con = _reconnect()
         except ldap.INVALID_CREDENTIALS:
             raise MoulinetteError("invalid_password")
         except ldap.SERVER_DOWN:
-            logger.exception("unable to reach the server to authenticate")
-            raise MoulinetteError("ldap_server_down")
+            # ldap is down, attempt to restart it before really failing
+            logger.warning(m18n.g("ldap_server_down"))
+            os.system("systemctl restart slapd")
+            time.sleep(10)  # waits 10 secondes so we are sure that slapd has restarted
+
+            try:
+                con = _reconnect()
+            except ldap.SERVER_DOWN:
+                raise MoulinetteLdapIsDownError("ldap_server_down")
 
         # Check that we are indeed logged in with the right identity
         try:

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -438,6 +438,10 @@ class MoulinetteError(Exception):
         self.strerror = msg
 
 
+class MoulinetteLdapIsDownError(MoulinetteError):
+    """Used when ldap is down"""
+
+
 class MoulinetteLock(object):
 
     """Locker for a moulinette instance


### PR DESCRIPTION
Slapd is annoying has hell and sometime it just randomly down for example when the debian package has been updated.

To try to avoid some random annoying errors try to restart it at least once and try to reconnect to it before really failing.