### PR TITLE
Allow python functions to return a raw HTTPResponse

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -577,6 +577,9 @@ def format_for_response(content):
             return ""
         response.status = 200
 
+    if isinstance(content, HTTPResponse):
+        return content
+
     # Return JSON-style response
     response.content_type = "application/json"
     return json_encode(content, cls=JSONExtendedEncoder)


### PR DESCRIPTION
Allow the namespace (e.g. yunohost)'s python function to return raw HTTPResponse ... In particular, the initial motivation for this is to allow the download of backups from Yunohost API, which can be done by returning a `bottle.static_file` (which is a simple wrapper from bottle to return a file as the HTTP response)

Related PR in yunohost : https://github.com/YunoHost/yunohost/pull/1046