### PR TITLE
[enh] add a msignal.file_display capability for cli

### DIFF
--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -307,7 +307,7 @@ class MoulinetteSignals(object):
     # Signals definitions
 
     """The list of available signals"""
-    signals = {"authenticate", "prompt", "display"}
+    signals = {"authenticate", "prompt", "display", "file_display"}
 
     def authenticate(self, authenticator):
         """Process the authentication
@@ -365,6 +365,19 @@ class MoulinetteSignals(object):
         """
         try:
             self._display(message, style)
+        except NotImplementedError:
+            pass
+
+    def file_display(self, file_path):
+        """Display a message
+
+        Display the content of a file at file_path.
+
+        Keyword arguments:
+            - file_path -- The path to the file
+        """
+        try:
+            self._file_display(file_path)
         except NotImplementedError:
             pass
 


### PR DESCRIPTION
This new `msignals.file_display(file_path)` allow to display the content of a file, either by printing it if it's not too high for the current shell dimensions or by displaying it into less otherwise.

This is obviously for the DESCRIPTION.md PR of yunohost