### PR TITLE
Fix argparse

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -90,7 +90,7 @@ class CommentParameter(_ExtraParameter):
     skipped_iface = ["api"]
 
     def __call__(self, message, arg_name, arg_value):
-        if arg_value:
+        if arg_value is None:
             return
         return msignals.display(m18n.n(message))
 


### PR DESCRIPTION
https://github.com/YunoHost/yunohost/pull/1075#discussion_r551045491

`arg_value` is the value of the `const` https://github.com/cricriiiiii/yunohost/blob/aefdd424d8dcb3209dc51c381af62debf9914039/data/actionsmap/yunohost.yml#L169 when we use the corresponding argument, else `None`