### PR TITLE
wait 1s for message in call_async_output

### DIFF
--- a/moulinette/utils/process.py
+++ b/moulinette/utils/process.py
@@ -77,7 +77,7 @@ def call_async_output(args, callback, **kwargs):
 
             while True:
                 try:
-                    callback, message = log_queue.get_nowait()
+                    callback, message = log_queue.get(True, 1)
                 except queue.Empty:
                     break
 


### PR DESCRIPTION
The CPU is 100% used during an app install because of the `get_nowait()`, I think we can wait a little :-°