### PR TITLE
[fix] Unicode password doesn't log in

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -249,7 +249,7 @@ class _ActionsMapPlugin(object):
             def wrapper():
                 kwargs = {}
                 try:
-                    kwargs["password"] = request.POST["password"]
+                    kwargs["password"] = request.POST.password
                 except KeyError:
                     raise HTTPResponse("Missing password parameter", 400)
 


### PR DESCRIPTION
## The problem
Yunohost instance with admin password with an accent or unicde char can't login webadmin / api

https://github.com/YunoHost/issues/issues/1801

## The solution
Bottle is quite strange, if you do request.POST['password'] it differs from request.POST.password ><

https://stackoverflow.com/questions/27432211/python-bottle-requests-and-unicode

## Status
Tested on an lxd ynh-dev container