### PR TITLE
[fix] Avoid warning and use safeloader

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -384,7 +384,7 @@ class ExtraArgumentParser(object):
 
 
 def ordered_yaml_load(stream):
-    class OrderedLoader(yaml.Loader):
+    class OrderedLoader(yaml.SafeLoader):
         pass
 
     OrderedLoader.add_constructor(


### PR DESCRIPTION
I tested some ynh command in app category. Seems working well.
See https://github.com/YunoHost/yunohost/pull/1287