### PR TITLE
[enh] Add prefill and multiline in prompt

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,7 @@
     "confirm": "Confirm {prompt}",
     "deprecated_command": "'{prog} {command}' is deprecated and will be removed in the future",
     "deprecated_command_alias": "'{prog} {old}' is deprecated and will be removed in the future, use '{prog} {new}' instead",
+    "edit_text_question": "{}. Edit this text ? [yN]: ",
     "error": "Error:",
     "file_not_exist": "File does not exist: '{path}'",
     "folder_exists": "Folder already exists: '{path}'",

--- a/moulinette/interfaces/cli.py
+++ b/moulinette/interfaces/cli.py
@@ -542,9 +542,10 @@ class Interface:
             elif is_multiline:
                 while True:
                     value = input(colorize(m18n.g("edit_text_question", message), color))
-                    if value in ["", "n", "N", "no", "NO"]:
+                    value = value.lower().strip()
+                    if value in ["", "n", "no"]:
                         return prefill
-                    elif value in ['y', 'yes', 'Y', 'YES']:
+                    elif value in ['y', 'yes']:
                         break
 
                 initial_message = prefill.encode('utf-8')

--- a/moulinette/utils/filesystem.py
+++ b/moulinette/utils/filesystem.py
@@ -67,16 +67,17 @@ def read_json(file_path):
     return loaded_json
 
 
-def read_yaml(file_path):
+def read_yaml(file_):
     """
     Safely read a yaml file
 
     Keyword argument:
-        file_path -- Path to the yaml file
+        file -- Path or stream to the yaml file
     """
 
     # Read file
-    file_content = read_file(file_path)
+    file_path = file_ if isinstance(file_, str) else file_.name
+    file_content = read_file(file_) if isinstance(file_, str) else file_
 
     # Try to load yaml to check if it's syntaxically correct
     try:


### PR DESCRIPTION
## The problem
For config panel and the vpn client refactoring, i need to create a question to edit the ovpn template. Here is a solution for the CLI way.

In more, i needed to expose the value already registered in question, so i add the prefill argument instead of a simple '(default: VALUE)' display.

## The solution
Run the default edirot to edit multiline text
Prefill prompt question with the default or current value.