### PR TITLE
api: Move cookie session management logic to the authenticator for more flexibility

### DIFF
--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -414,6 +414,9 @@ class ActionsMap(object):
             # Read actions map from yaml file
             actionsmap = read_yaml(actionsmap_yml)
 
+            if not actionsmap["_global"].get("cache", True):
+                return actionsmap
+
             # Delete old cache files
             for old_cache in glob.glob(f"{actionsmap_yml_dir}/.{actionsmap_yml_file}.*.pkl"):
                 os.remove(old_cache)
@@ -536,7 +539,7 @@ class ActionsMap(object):
             full_action_name = "%s.%s.%s" % (namespace, category, action)
 
         # Lock the moulinette for the namespace
-        with MoulinetteLock(namespace, timeout):
+        with MoulinetteLock(namespace, timeout, self.enable_lock):
             start = time()
             try:
                 mod = __import__(
@@ -618,6 +621,7 @@ class ActionsMap(object):
         _global = actionsmap.pop("_global", {})
 
         self.namespace = _global["namespace"]
+        self.enable_lock = _global.get("lock", True)
         self.default_authentication = _global["authentication"][
             interface_type
         ]

--- a/moulinette/actionsmap.py
+++ b/moulinette/actionsmap.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from time import time
 from collections import OrderedDict
 from importlib import import_module
+from functools import cache
 
 from moulinette import m18n, Moulinette
 from moulinette.core import (
@@ -456,6 +457,7 @@ class ActionsMap(object):
         self.extraparser = ExtraArgumentParser(top_parser.interface)
         self.parser = self._construct_parser(actionsmap, top_parser)
 
+    @cache
     def get_authenticator(self, auth_method):
 
         if auth_method == "default":
@@ -616,7 +618,6 @@ class ActionsMap(object):
         _global = actionsmap.pop("_global", {})
 
         self.namespace = _global["namespace"]
-        self.cookie_name = _global["cookie_name"]
         self.default_authentication = _global["authentication"][
             interface_type
         ]

--- a/moulinette/core.py
+++ b/moulinette/core.py
@@ -291,10 +291,11 @@ class MoulinetteLock(object):
 
     base_lockfile = "/var/run/moulinette_%s.lock"
 
-    def __init__(self, namespace, timeout=None, interval=0.5):
+    def __init__(self, namespace, timeout=None, enable_lock=True, interval=0.5):
         self.namespace = namespace
         self.timeout = timeout
         self.interval = interval
+        self.enable_lock = enable_lock
 
         self._lockfile = self.base_lockfile % namespace
         self._stale_checked = False
@@ -421,7 +422,7 @@ class MoulinetteLock(object):
         return False
 
     def __enter__(self):
-        if not self._locked:
+        if self.enable_lock and not self._locked:
             self.acquire()
         return self
 

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -29,7 +29,6 @@ from moulinette.interfaces import (
     JSONExtendedEncoder,
 )
 from moulinette.utils import log
-from moulinette.utils.text import random_ascii
 
 logger = log.getLogger("moulinette.interface.api")
 

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -90,6 +90,11 @@ class APIQueueHandler(logging.Handler):
 
     def emit(self, record):
 
+        # Prevent triggering this function while moulinette
+        # is being initialized with --debug
+        if not self.actionsmap or len(request.cookies) == 0:
+            return
+
         profile = request.params.get("profile", self.actionsmap.default_authentication)
         authenticator = self.actionsmap.get_authenticator(profile)
 
@@ -484,6 +489,8 @@ class _ActionsMapPlugin(object):
             try:
                 s_id = authenticator.get_session_cookie()["id"]
                 queue = self.log_queues[s_id]
+            except MoulinetteAuthenticationError:
+                pass
             except KeyError:
                 pass
             else:

--- a/test/actionsmap/moulitest.yml
+++ b/test/actionsmap/moulitest.yml
@@ -4,7 +4,6 @@
 #############################
 _global:
     namespace: moulitest
-    cookie_name: moulitest
     authentication:
         api: dummy
         cli: dummy

--- a/test/src/authenticators/dummy.py
+++ b/test/src/authenticators/dummy.py
@@ -61,6 +61,9 @@ class Authenticator(BaseAuthenticator):
                 return {"id": random_ascii()}
             raise MoulinetteAuthenticationError("unable_authenticate")
 
+        if not infos and raise_if_no_session_exists:
+            raise MoulinetteAuthenticationError("unable_authenticate")
+
         if "id" not in infos:
             infos["id"] = random_ascii()
 

--- a/test/src/authenticators/dummy.py
+++ b/test/src/authenticators/dummy.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from moulinette.core import MoulinetteError
+from moulinette.utils.text import random_ascii
+from moulinette.core import MoulinetteError, MoulinetteAuthenticationError
 from moulinette.authentication import BaseAuthenticator
 
-logger = logging.getLogger("moulinette.authenticator.dummy")
+logger = logging.getLogger("moulinette.authenticator.yoloswag")
 
 # Dummy authenticator implementation
+
+session_secret = random_ascii()
 
 
 class Authenticator(BaseAuthenticator):
@@ -24,3 +27,50 @@ class Authenticator(BaseAuthenticator):
             raise MoulinetteError("invalid_password", raw_msg=True)
 
         return
+
+    def set_session_cookie(self, infos):
+
+        from bottle import response
+
+        assert isinstance(infos, dict)
+
+        # This allows to generate a new session id or keep the existing one
+        current_infos = self.get_session_cookie(raise_if_no_session_exists=False)
+        new_infos = {"id": current_infos["id"]}
+        new_infos.update(infos)
+
+        response.set_cookie(
+            "moulitest",
+            new_infos,
+            secure=True,
+            secret=session_secret,
+            httponly=True,
+            # samesite="strict", # Bottle 0.12 doesn't support samesite, to be added in next versions
+        )
+
+    def get_session_cookie(self, raise_if_no_session_exists=True):
+
+        from bottle import request
+
+        try:
+            infos = request.get_cookie(
+                "moulitest", secret=session_secret, default={}
+            )
+        except Exception:
+            if not raise_if_no_session_exists:
+                return {"id": random_ascii()}
+            raise MoulinetteAuthenticationError("unable_authenticate")
+
+        if "id" not in infos:
+            infos["id"] = random_ascii()
+
+        return infos
+
+    @staticmethod
+    def delete_session_cookie(self):
+
+        from bottle import response
+
+        response.set_cookie("moulitest", "", max_age=-1)
+        response.delete_cookie("moulitest")
+

--- a/test/src/authenticators/dummy.py
+++ b/test/src/authenticators/dummy.py
@@ -69,7 +69,6 @@ class Authenticator(BaseAuthenticator):
 
         return infos
 
-    @staticmethod
     def delete_session_cookie(self):
 
         from bottle import response

--- a/test/src/authenticators/yoloswag.py
+++ b/test/src/authenticators/yoloswag.py
@@ -61,6 +61,9 @@ class Authenticator(BaseAuthenticator):
                 return {"id": random_ascii()}
             raise MoulinetteAuthenticationError("unable_authenticate")
 
+        if not infos and raise_if_no_session_exists:
+            raise MoulinetteAuthenticationError("unable_authenticate")
+
         if "id" not in infos:
             infos["id"] = random_ascii()
 

--- a/test/src/authenticators/yoloswag.py
+++ b/test/src/authenticators/yoloswag.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from moulinette.core import MoulinetteError
+from moulinette.utils.text import random_ascii
+from moulinette.core import MoulinetteError, MoulinetteAuthenticationError
 from moulinette.authentication import BaseAuthenticator
 
 logger = logging.getLogger("moulinette.authenticator.yoloswag")
 
 # Dummy authenticator implementation
+
+session_secret = random_ascii()
 
 
 class Authenticator(BaseAuthenticator):
@@ -24,3 +27,50 @@ class Authenticator(BaseAuthenticator):
             raise MoulinetteError("invalid_password", raw_msg=True)
 
         return
+
+    def set_session_cookie(self, infos):
+
+        from bottle import response
+
+        assert isinstance(infos, dict)
+
+        # This allows to generate a new session id or keep the existing one
+        current_infos = self.get_session_cookie(raise_if_no_session_exists=False)
+        new_infos = {"id": current_infos["id"]}
+        new_infos.update(infos)
+
+        response.set_cookie(
+            "moulitest",
+            new_infos,
+            secure=True,
+            secret=session_secret,
+            httponly=True,
+            # samesite="strict", # Bottle 0.12 doesn't support samesite, to be added in next versions
+        )
+
+    def get_session_cookie(self, raise_if_no_session_exists=True):
+
+        from bottle import request
+
+        try:
+            infos = request.get_cookie(
+                "moulitest", secret=session_secret, default={}
+            )
+        except Exception:
+            if not raise_if_no_session_exists:
+                return {"id": random_ascii()}
+            raise MoulinetteAuthenticationError("unable_authenticate")
+
+        if "id" not in infos:
+            infos["id"] = random_ascii()
+
+        return infos
+
+    @staticmethod
+    def delete_session_cookie(self):
+
+        from bottle import response
+
+        response.set_cookie("moulitest", "", max_age=-1)
+        response.delete_cookie("moulitest")
+

--- a/test/src/authenticators/yoloswag.py
+++ b/test/src/authenticators/yoloswag.py
@@ -69,7 +69,6 @@ class Authenticator(BaseAuthenticator):
 
         return infos
 
-    @staticmethod
     def delete_session_cookie(self):
 
         from bottle import response

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -66,7 +66,7 @@ class TestAuthAPI:
     def test_login(self, moulinette_webapi):
         assert self.login(moulinette_webapi).text == "Logged in"
 
-        assert "session.moulitest" in moulinette_webapi.cookies
+        assert "moulitest" in moulinette_webapi.cookies
 
     def test_login_bad_password(self, moulinette_webapi):
         assert (
@@ -74,7 +74,7 @@ class TestAuthAPI:
             == "invalid_password"
         )
 
-        assert "session.moulitest" not in moulinette_webapi.cookies
+        assert "moulitest" not in moulinette_webapi.cookies
 
     def test_login_csrf_attempt(self, moulinette_webapi):
         # C.f.
@@ -86,7 +86,7 @@ class TestAuthAPI:
             in self.login(moulinette_webapi, csrf=True, status=403).text
         )
         assert not any(
-            c.name == "session.moulitest" for c in moulinette_webapi.cookiejar
+            c.name == "moulitest" for c in moulinette_webapi.cookiejar
         )
 
     def test_login_then_legit_request_without_cookies(self, moulinette_webapi):
@@ -99,7 +99,7 @@ class TestAuthAPI:
     def test_login_then_legit_request(self, moulinette_webapi):
         self.login(moulinette_webapi)
 
-        assert "session.moulitest" in moulinette_webapi.cookies
+        assert "moulitest" in moulinette_webapi.cookies
 
         assert (
             moulinette_webapi.get("/test-auth/default", status=200).text
@@ -124,7 +124,7 @@ class TestAuthAPI:
     def test_login_other_profile(self, moulinette_webapi):
         self.login(moulinette_webapi, profile="yoloswag", password="yoloswag")
 
-        assert "session.moulitest" in moulinette_webapi.cookies
+        assert "moulitest" in moulinette_webapi.cookies
 
     def test_login_wrong_profile(self, moulinette_webapi):
         self.login(moulinette_webapi)


### PR DESCRIPTION
c.f. https://github.com/YunoHost/yunohost/pull/1394