### PR TITLE
[fix] CORS Prefech OPTIONS

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -727,12 +727,6 @@ class Interface:
         # TODO: Return OK to 'OPTIONS' xhr requests (l173)
         app = Bottle(autojson=True)
 
-        # Wrapper which sets proper header
-        # Doesn't work if the HTTPResponse has been raised
-        # like HTTP Error
-        def apiheader():
-            response.set_header("Access-Control-Allow-Origin", "*")
-
         # Attempt to retrieve and set locale
         def api18n(callback):
             def wrapper(*args, **kwargs):
@@ -747,7 +741,6 @@ class Interface:
 
         # Install plugins
         app.install(filter_csrf)
-        app.add_hook("after_request", apiheader)
         app.install(api18n)
         actionsmapplugin = _ActionsMapPlugin(actionsmap, log_queues)
         app.install(actionsmapplugin)
@@ -760,9 +753,6 @@ class Interface:
         # and our damned swagger api documentation tool
         def options_prefetch_cors():
             response = HTTPResponse("", 200)
-            response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Headers", "x-requested-with")
-            response.set_header("Allow", "GET, POST, PUT, DELETE, OPTIONS")
             return response
 
         app.route('/<:re:.*>', method="OPTIONS",


### PR DESCRIPTION
## The problem
https://github.com/YunoHost/issues/issues/1533

We had the same issues to integrate swagger API into the documentation of YunoHost

## The solution
It's a partial solutions, cause the hook doesn't work to return cors on HTTP Errors... 
To coturn that we use nginx instead to add the good headers