### PR TITLE
Bypass CSRF protection for the /yunohost/portalapi/login route

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -272,7 +272,7 @@ class _ActionsMapPlugin:
             name="login",
             method="POST",
             callback=self.login,
-            skip=["actionsmap"],
+            skip=[filter_csrf, "actionsmap"],
         )
         app.route(
             "/logout",
@@ -362,9 +362,12 @@ class _ActionsMapPlugin:
             credentials = request.json["credentials"]
             profile = request.json.get("profile", self.actionsmap.default_authentication)
         else:
-            if "credentials" not in request.params:
+            if "credentials" in request.params:
+                credentials = request.params["credentials"]
+            else:
+                if "username" in request.params and "password" in request.params:
+                    credentials = request.params["username"] + ":" + request.params["password"]
                 raise HTTPResponse("Missing credentials parameter", 400)
-            credentials = request.params["credentials"]
 
             profile = request.params.get("profile", self.actionsmap.default_authentication)
 


### PR DESCRIPTION
Allowing login from simple HTML form... Demo using my_webapp form:

```
<!DOCTYPE html>
<html>
  <head>
    <title>Yunohost SSO</title>
  </head>
  <body>
<?php
    if (array_key_exists("REMOTE_USER", $_SERVER)) {
        echo "Welcome, " . $_SERVER["REMOTE_USER"] . "!";
        echo "<br><a href='/yunohost/portalapi/logout'>Log out<br>";
    } else {
?>
    <form method="POST" action="/yunohost/portalapi/login">
        <input type="text" name="username" id="username">
        <br><input type="password" name="password" id="password">
        <br><input type="submit">
    </form>
<?php
    }
?>
  </body>
</html>
```

Note login and logout route do not redirect anywhere right now so it's not convenient ® yet.