### PR TITLE
portal-api: Bypass CSRF protection for login route

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -272,13 +272,14 @@ class _ActionsMapPlugin:
             name="login",
             method="POST",
             callback=self.login,
-            skip=["actionsmap"],
+            skip=[filter_csrf, "actionsmap"],
         )
         app.route(
             "/logout",
             name="logout",
             method="GET",
             callback=self.logout,
+            # No need to bypass CSRF here because filter allows GET requests
             skip=["actionsmap"],
         )
 
@@ -362,9 +363,12 @@ class _ActionsMapPlugin:
             credentials = request.json["credentials"]
             profile = request.json.get("profile", self.actionsmap.default_authentication)
         else:
-            if "credentials" not in request.params:
+            if "credentials" in request.params:
+                credentials = request.params["credentials"]
+            elif "username" in request.params and "password" in request.params:
+                credentials = request.params["username"] + ":" + request.params["password"]
+            else:
                 raise HTTPResponse("Missing credentials parameter", 400)
-            credentials = request.params["credentials"]
 
             profile = request.params.get("profile", self.actionsmap.default_authentication)
 


### PR DESCRIPTION
Allowing login from simple HTML form
Also allow to pass username/password as two params instead of a combined "credentials"

Demo using my_webapp:

```
<!DOCTYPE html>
<html>
  <head>
    <title>Yunohost SSO</title>
  </head>
  <body>
<?php
    if (array_key_exists("REMOTE_USER", $_SERVER) && $_SERVER["REMOTE_USER"] != "") {
        echo "Welcome, " . $_SERVER["REMOTE_USER"] . "!";
        echo "<br><a href='/yunohost/portalapi/logout?referer_redirect'>Log out<br>";
    } else {
?>
    <form method="POST" action="/yunohost/portalapi/login?referer_redirect">
        <input type="text" name="username" id="username">
        <br><input type="password" name="password" id="password">
        <br><input type="submit">
    </form>
<?php
    }
?>
  </body>
</html>
```