### PR TITLE
chore: update actions version to use node 16 version

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check / auto apply black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check files using the black formatter
         uses: rickstaa/action-black@v1
         id: action_black

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -8,7 +8,7 @@ jobs:
     name: Autoreformat locale files
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Apply reformating scripts
           id: action_reformat
           run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install apt dependencies
@@ -34,9 +34,9 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox


### PR DESCRIPTION
Node 12 version is deprecated since April 2022.

> Node.js 12 actions are deprecated. For more information see: [github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2