### PR TITLE
ci(autoblack): Input 'black_args' has been deprecated with message: Input  is deprecated. Use  and  instead.

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -13,7 +13,7 @@ jobs:
         uses: psf/black@stable
         id: black
         with:
-          black_args: "."
+          options: "."
         continue-on-error: true
       - name: Create Pull Request
         if: steps.black.outputs.is_formatted == 'true'


### PR DESCRIPTION
see the warning here: https://github.com/YunoHost/moulinette/actions/runs/8181029221