### PR TITLE
API - Add support for request content in JSON

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import json
 import re
 import errno
 import logging
@@ -314,25 +314,29 @@ class _ActionsMapPlugin:
             for a in args:
                 params[a] = True
 
-            # Append other request params
-            req_params = list(request.params.dict.items())
-            # TODO test special chars in filename
-            req_params += list(request.files.dict.items())
-            for k, v in req_params:
-                v = _format(v)
-                if k not in params.keys():
-                    params[k] = v
-                else:
-                    curr_v = params[k]
-                    # Append param value to the list
-                    if not isinstance(curr_v, list):
-                        curr_v = [curr_v]
-                    if isinstance(v, list):
-                        for i in v:
-                            curr_v.append(i)
+            if request.content_type == "application/json":
+                # Manage in REST with JSON content mode
+                params.update(json.loads(list(request.params.dict.keys())[0]))
+            else:
+                # Append other request params
+                req_params = list(request.params.dict.items())
+                # TODO test special chars in filename
+                req_params += list(request.files.dict.items())
+                for k, v in req_params:
+                    v = _format(v)
+                    if k not in params.keys():
+                        params[k] = v
                     else:
-                        curr_v.append(v)
-                    params[k] = curr_v
+                        curr_v = params[k]
+                        # Append param value to the list
+                        if not isinstance(curr_v, list):
+                            curr_v = [curr_v]
+                        if isinstance(v, list):
+                            for i in v:
+                                curr_v.append(i)
+                        else:
+                            curr_v.append(v)
+                        params[k] = curr_v
 
             # Process the action
             return callback((request.method, context.rule), params)


### PR DESCRIPTION
# Problem

Using yunhost admin API with as REST API has not issue.

By example when we use it with the requests lib passing the parameter is straightforward. And I didn't find a working solution to pass correctly an `UTF-8` easily with `requests`.

# Solution

Add a working support for REST request with JSON content type.

Note that for now the authentication is not supported by this way. But the issue currently is on the other request which could be difficult to write to make it working correctly.

# How to test

By example we requests we can test this way:

```python3
import requests
s = requests.Session()
s.headers['X-Requested-With'] = 'Client'
s.post("https://domain.tld/yunohost/api/login", data={"credentials": "%s:%s" % ("user", "pwd")})
s.post("https://domain.tld/yunohost/api/users", json={"username": "yolotest", "fullname": "Fullname Withspécialchàr", "password": "pwd", "domain": "domain.tld"})
```


