### PR TITLE
interfaces/api: Allow a unix socket to be used instead of a host/port.

### DIFF
--- a/moulinette/__init__.py
+++ b/moulinette/__init__.py
@@ -112,6 +112,46 @@ def api(
     return 0
 
 
+def socket_api(
+    socket_path: str,
+    routes={},
+    actionsmap=None,
+    locales_dir=None,
+    allowed_cors_origins=[],
+) -> int:
+    """Web server (API) interface on a socket
+
+    Run a HTTP server with the moulinette for an API usage.
+
+    Keyword arguments:
+        - socket_path -- Path of a socket to expose
+        - routes -- A dict of additional routes to add in the form of
+            {(method, uri): callback}
+
+    """
+    from moulinette.interfaces.api import Interface as Api
+
+    m18n.set_locales_dir(locales_dir)
+
+    try:
+        Api(
+            routes=routes,
+            actionsmap=actionsmap,
+            allowed_cors_origins=allowed_cors_origins,
+            override_type="sockapi"
+        ).run(host=None, socket_path=socket_path)
+    except MoulinetteError as e:
+        import logging
+
+        logging.getLogger("moulinette").error(e.strerror)
+        return 1
+    except KeyboardInterrupt:
+        import logging
+
+        logging.getLogger("moulinette").info(m18n.g("operation_interrupted"))
+    return 0
+
+
 def cli(
     args, top_parser, output_as=None, timeout=None, actionsmap=None, locales_dir=None
 ):

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os
 import sys
 import re
 import errno
@@ -751,8 +752,11 @@ class Interface:
 
     type = "api"
 
-    def __init__(self, routes={}, actionsmap=None, allowed_cors_origins=[]):
-        actionsmap = ActionsMap(actionsmap, ActionsMapParser())
+    def __init__(self, routes={}, actionsmap=None, allowed_cors_origins=[], override_type: str | None = None):
+        parser = ActionsMapParser()
+        if override_type is not None:
+            parser.interface = override_type
+        actionsmap = ActionsMap(actionsmap, parser)
 
         self.allowed_cors_origins = allowed_cors_origins
 
@@ -827,30 +831,45 @@ class Interface:
 
         Moulinette._interface = self
 
-    def run(self, host="localhost", port=80):
+    def run(self, host="localhost", port=80, socket_path=None):
         """Run the moulinette
 
-        Start a server instance on the given port to serve moulinette
+        Start a server instance on the given port or socket to serve moulinette
         actions.
 
         Keyword arguments:
             - host -- Server address to bind to
             - port -- Server port to bind to
+            - socket_path -- If given, binds to a socket instead of a port.
 
         """
 
-        logger.debug(
-            "starting the server instance in %s:%d",
-            host,
-            port,
-        )
+        if socket_path:
+            logger.debug("starting the server instance in %s", socket_path)
+        else:
+            logger.debug("starting the server instance in %s:%d", host, port)
 
         try:
             from gevent.pywsgi import WSGIServer
             from geventwebsocket.handler import WebSocketHandler
 
-            server = WSGIServer((host, port), self._app, handler_class=WebSocketHandler)
-            server.serve_forever()
+            if socket_path:
+                from gevent import socket
+                listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                if os.path.exists(socket_path):
+                    os.remove(socket_path)
+                listener.bind(socket_path)
+                listener.listen()
+
+            else:
+                listener = (host, port)
+
+            server = WSGIServer(listener, self._app, handler_class=WebSocketHandler)
+            if socket_path:
+                server.serve_forever()
+            else:
+                server.start()
+
         except IOError as e:
             error_message = "unable to start the server instance on %s:%d: %s" % (
                 host,


### PR DESCRIPTION
This is exposed via the global socket_api() function.