### PR TITLE
[fix] String started with at was interpreted as option

### DIFF
--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -231,16 +231,14 @@ class _HTTPArgumentParser:
                 value.save(UPLOAD_DIR)
                 if option_string is not None:
                     arg_strings.append(option_string)
+                arg_strings.append(f"{UPLOAD_DIR}/{value.filename}")
+            elif isinstance(value, str):
                 # ==== SPACE DIRTY_HACK =====
                 # In order to avoid option injection by starting a value with a
-                # prefix_chars (here @), we add a starting space on all string
-                # values, like that argparse do not interpret it as an option...
-                # The space is removed in a post-treatment
-                # see https://github.com/python/cpython/issues/138950
-                arg_strings.append(f" {UPLOAD_DIR}/{value.filename}")
-            elif isinstance(value, str):
-                # Same space dirty hack as above
-                protected_value = f" {value}"
+                # prefix_chars (here @), we add a starting space on string values
+                # starting with @, like that argparse do not interpret it as an
+                # option...
+                protected_value = f" {value}" if value.startswith("@") else value
                 if option_string is not None:
                     arg_strings.append(option_string)
                     # TODO: Review this fix
@@ -256,7 +254,7 @@ class _HTTPArgumentParser:
                     if isinstance(v, str):
                         # Same space dirty hack as above
 
-                        protected_value = f" {v}"
+                        protected_value = f" {v}" if v.startswith("@") else v
                         arg_strings.append(protected_value)
                     else:
                         logger.warning(
@@ -276,28 +274,29 @@ class _HTTPArgumentParser:
             return arg_strings
 
         # Iterate over positional arguments
+        known_args = []
         for action in self._positional:
             if action.dest in args:
                 arg_strings = append(arg_strings, args[action.dest], action)
+                known_args.append((action.dest, args[action.dest]))
 
         # Iterate over optional arguments
         for dest, action in self._optional.items():
             if dest in args:
                 arg_strings = append(arg_strings, args[dest], action)
+                known_args.append((dest, args[dest]))
 
         parsed_args = self._parser.parse_args(arg_strings, namespace)
 
         # Post-treatment of the dirty hack describe above
         parsed_args_dict = vars(parsed_args)
-        known_args = [action.dest for action in self._positional]
-        known_args += list(self._optional.keys())
-        for option_string in known_args:
+        for option_string, value in known_args:
             if option_string not in args:
                 continue
-            value = parsed_args_dict[option_string]
-            if isinstance(value, str) and value[0] == " ":
-                # We remove the starting space we have added on all values...
-                setattr(parsed_args, option_string, value[1:])
+            protected_value = parsed_args_dict[option_string]
+            if isinstance(protected_value, str) and value.startswith("@"):
+                # We remove the starting space we have added on values starting with @...
+                setattr(parsed_args, option_string, protected_value[1:])
         return parsed_args
 
     def _error(self, message):

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -282,8 +282,9 @@ class _HTTPArgumentParser:
             if dest in args:
                 arg_strings = append(arg_strings, args[dest], action)
 
-        # Post-treatment of the dirty hack describe above
         parsed_args = self._parser.parse_args(arg_strings, namespace)
+
+        # Post-treatment of the dirty hack describe above
         parsed_args_dict = vars(parsed_args)
         known_args = [action.dest for action in self._positional]
         known_args += list(self._optional.keys())

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -232,7 +232,7 @@ class _HTTPArgumentParser:
                 # In order to avoid option injection by starting a value with @
                 # we add a starting space on all string values, like that argparse
                 # do not interpret it as an option...
-                # The space is remove in a post-treatment
+                # The space is removed in a post-treatment
                 # see https://github.com/python/cpython/issues/138950
                 arg_strings.append(f" {UPLOAD_DIR}/{value.filename}")
             elif isinstance(value, str):

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -147,6 +147,9 @@ def best_locale_match_from_accept_language_header() -> str:
     return m18n.default_locale
 
 
+# FIXME This parser transform API call into CLI command and parse
+# it with argparse. There are probably method to validate and ordering
+# API arguments without relying on argparse cli tools
 class _HTTPArgumentParser:
     """Argument parser for HTTP requests
 
@@ -229,9 +232,9 @@ class _HTTPArgumentParser:
                 if option_string is not None:
                     arg_strings.append(option_string)
                 # ==== SPACE DIRTY_HACK =====
-                # In order to avoid option injection by starting a value with @
-                # we add a starting space on all string values, like that argparse
-                # do not interpret it as an option...
+                # In order to avoid option injection by starting a value with a
+                # prefix_chars (here @), we add a starting space on all string
+                # values, like that argparse do not interpret it as an option...
                 # The space is removed in a post-treatment
                 # see https://github.com/python/cpython/issues/138950
                 arg_strings.append(f" {UPLOAD_DIR}/{value.filename}")

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -228,21 +228,33 @@ class _HTTPArgumentParser:
                 value.save(UPLOAD_DIR)
                 if option_string is not None:
                     arg_strings.append(option_string)
-                arg_strings.append(UPLOAD_DIR + "/" + value.filename)
+                # ==== SPACE DIRTY_HACK =====
+                # In order to avoid option injection by starting a value with @
+                # we add a starting space on all string values, like that argparse
+                # do not interpret it as an option...
+                # The space is remove in a post-treatment
+                # see https://github.com/python/cpython/issues/138950
+                arg_strings.append(f" {UPLOAD_DIR}/{value.filename}")
             elif isinstance(value, str):
+                # Same space dirty hack as above
+                protected_value = f" {value}"
                 if option_string is not None:
                     arg_strings.append(option_string)
                     # TODO: Review this fix
+                    # FIXME What if value is an empty string ?
                     if value:
-                        arg_strings.append(value)
+                        arg_strings.append(protected_value)
                 else:
-                    arg_strings.append(value)
+                    arg_strings.append(protected_value)
             elif isinstance(value, list):
                 if option_string is not None:
                     arg_strings.append(option_string)
                 for v in value:
                     if isinstance(v, str):
-                        arg_strings.append(v)
+                        # Same space dirty hack as above
+
+                        protected_value = f" {v}"
+                        arg_strings.append(protected_value)
                     else:
                         logger.warning(
                             "unsupported argument value type %r "
@@ -270,7 +282,13 @@ class _HTTPArgumentParser:
             if dest in args:
                 arg_strings = append(arg_strings, args[dest], action)
 
-        return self._parser.parse_args(arg_strings, namespace)
+        # Post-treatment of the dirty hack describe above
+        parsed_args = self._parser.parse_args(arg_strings, namespace)
+        for option_string, value in vars(parsed_args).items():
+            if isinstance(value, str) and option_string not in ["loginShell", "_tid"]:
+                # We remove the starting space we have added on all values...
+                setattr(parsed_args, option_string, value[1:])
+        return parsed_args
 
     def _error(self, message):
         raise MoulinetteValidationError(message, raw_msg=True)

--- a/moulinette/interfaces/api.py
+++ b/moulinette/interfaces/api.py
@@ -284,8 +284,14 @@ class _HTTPArgumentParser:
 
         # Post-treatment of the dirty hack describe above
         parsed_args = self._parser.parse_args(arg_strings, namespace)
-        for option_string, value in vars(parsed_args).items():
-            if isinstance(value, str) and option_string not in ["loginShell", "_tid"]:
+        parsed_args_dict = vars(parsed_args)
+        known_args = [action.dest for action in self._positional]
+        known_args += list(self._optional.keys())
+        for option_string in known_args:
+            if option_string not in args:
+                continue
+            value = parsed_args_dict[option_string]
+            if isinstance(value, str) and value[0] == " ":
                 # We remove the starting space we have added on all values...
                 setattr(parsed_args, option_string, value[1:])
         return parsed_args


### PR DESCRIPTION
## The problem
Text related to an API option and starting with an at are interpreted as options and not as values !

Related issues: https://github.com/YunoHost/issues/issues/2557

## The solution
It's an argparse bug https://github.com/python/cpython/issues/138950

Some comments suggest to use the equal notation but it doesn't work for positional arguments...

SO i found a dirty workaround cause no easy way to escape the value exists (doesn't really make sens in the usual context of argparse i guess...). I add a space at the beggining of the string and remove it just at the end of the wrapper function.

**AI transparency:** no AI used
## PR Status

Tested manually

## Code TODOs
seems ready


## Tests TODOs

Indicate here tests you have already done, and tests you think should be done

 - [x] Call the code through webadmin call by hand and use a logger.warning to get the value of the return
 - [x] Change a user password starting with @ and log with it
 - [ ] Test to upload a file
 - [x] Test an option allowing several values as a list 

## How to test

